### PR TITLE
Fix Movie Binding

### DIFF
--- a/Ruddarr/Models/Movies.swift
+++ b/Ruddarr/Models/Movies.swift
@@ -27,18 +27,17 @@ class Movies {
     func byId(_ id: Movie.ID) -> Binding<Movie?> {
         Binding(
             get: { [weak self] in
-                guard let index = self?.items.firstIndex(where: { $0.movieId == id }) else {
+                guard let index = self?.items.firstIndex(where: { $0.id == id }) else {
                     return nil
                 }
 
                 return self?.items[index]
             },
             set: { [weak self] in
-                guard let index = self?.items.firstIndex(where: { $0.movieId == id }) else {
+                guard let index = self?.items.firstIndex(where: { $0.id == id }) else {
                     if let newValue = $0 {
                         self?.items.append(newValue)
                     }
-
                     return
                 }
 

--- a/Ruddarr/Utilities/Binding.swift
+++ b/Ruddarr/Utilities/Binding.swift
@@ -25,14 +25,15 @@ extension Binding {
 
 extension Binding where Value: OptionalProtocol {
     var unwrapped: Binding<Value.Wrapped>? {
-        guard let wrappedValue = self.wrappedValue.wrappedValue else {
+        guard var wrappedValue = self.wrappedValue.wrappedValue else {
             return nil
         }
 
         return .init {
             wrappedValue
         } set: {
-            self.wrappedValue.wrappedValue = $0
+            wrappedValue = $0
+            self.wrappedValue.wrappedValue = wrappedValue
         }
     }
 }

--- a/Ruddarr/Views/Movies/MovieView.swift
+++ b/Ruddarr/Views/Movies/MovieView.swift
@@ -117,6 +117,7 @@ struct MovieView: View {
         }
     }
 
+    @MainActor
     func toggleMonitor() async {
         print("before toggle", movie.monitored)
         movie.monitored.toggle()


### PR DESCRIPTION
Closes $65

@tillkruss Binding.unwrapped (which replaces the buggy/crashing built in `Binding.init(_:)` was the problem. I've used this before and it works well "eventually", i.e. some parent view will re-render, the changes will trickle down and a new Binding will get created with the appropriate value. But, since re-render isn't immediate, it was not suitable for reading the updated value right away. I've update it accordingly to also update the internal value of the Binding. This should work but Im saying this because the approach is not battle tested. Be wary of `Binding.unwrapped` if you see issues in the future.

I also moved a method to the main actor. Unlike older view state solutions, `@Observable` is thread safe, but thats not to say there can't be race conditions in our code, so this way it feels safer.