### PR TITLE
explicitly set indent settings

### DIFF
--- a/Ruddarr.xcodeproj/project.pbxproj
+++ b/Ruddarr.xcodeproj/project.pbxproj
@@ -303,7 +303,9 @@
 				BBE828552B4F2C7000C1E1D9 /* Ruddarr */,
 				BBE828542B4F2C7000C1E1D9 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		BBE828542B4F2C7000C1E1D9 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Whenever I do `ctrl+I` to reindent some file, I end up committing some empty lines which produce needless merge conflicts. Im on default xcode settings, but that shouldn't matter. I've set the default indentation at the xcodeproj level. I hope this makes the problems go away (although I though your code also had 4 spaces, it just also put indents on empty lines, idk if theres a setting for that).

We should be `ctrl+I`-proof if possible.