### PR TITLE
Replace poster overlay with title and subtitle

### DIFF
--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -852,6 +852,16 @@
         }
       }
     },
+    "Compact" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compact"
+          }
+        }
+      }
+    },
     "Connect a %@ instance under %@." : {
       "localizations" : {
         "en" : {
@@ -1423,6 +1433,16 @@
         }
       }
     },
+    "Expanded" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expanded"
+          }
+        }
+      }
+    },
     "Expired" : {
       "localizations" : {
         "en" : {
@@ -1669,6 +1689,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Greek"
+          }
+        }
+      }
+    },
+    "Grid Layout" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grid Layout"
           }
         }
       }

--- a/Ruddarr/Services/AppSettings.swift
+++ b/Ruddarr/Services/AppSettings.swift
@@ -9,6 +9,7 @@ class AppSettings: ObservableObject {
 
     @AppStorage("icon", store: dependencies.store) var icon: AppIcon = .factory
     @AppStorage("theme", store: dependencies.store) var theme: Theme = .factory
+    @AppStorage("layout", store: dependencies.store) var layout: ViewLayout = .compact
     @AppStorage("appearance", store: dependencies.store) var appearance: Appearance = .automatic
     @AppStorage("radarrInstanceId", store: dependencies.store) var radarrInstanceId: Instance.ID?
     @AppStorage("sonarrInstanceId", store: dependencies.store) var sonarrInstanceId: Instance.ID?

--- a/Ruddarr/Services/Theme.swift
+++ b/Ruddarr/Services/Theme.swift
@@ -107,6 +107,20 @@ enum AppIcon: String, Identifiable, CaseIterable {
     }
 }
 
+enum ViewLayout: String, Identifiable, CaseIterable {
+    case compact
+    case expanded
+
+    var id: Self { self }
+
+    var label: LocalizedStringKey {
+        switch self {
+        case .compact: "Compact"
+        case .expanded: "Expanded"
+        }
+    }
+}
+
 struct AppIconData {
     var label: LocalizedStringKey
     var asset: String

--- a/Ruddarr/Views/Movies/MovieGridItem.swift
+++ b/Ruddarr/Views/Movies/MovieGridItem.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 struct MovieGridItem: View {
+    @EnvironmentObject var settings: AppSettings
     var movie: Movie
 
     var body: some View {
-        VStack {
+        switch settings.layout {
+        case .compact:
             poster
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contextMenu {
@@ -13,22 +15,39 @@ struct MovieGridItem: View {
                     poster.frame(width: 300, height: 450)
                 }
                 .background(.secondarySystemBackground)
+                .overlay(alignment: .bottom) {
+                    if movie.exists {
+                        posterOverlay
+                    }
+                }
                 .clipShape(RoundedRectangle(cornerRadius: 10))
-            Group {
-                Text(movie.title).font(.footnote).fontWeight(.medium)
-                HStack(spacing: 4) {
-                    Group {
-                        if movie.isDownloaded {
-                            Image(systemName: "checkmark").symbolVariant(.circle.fill)
-                        } else if movie.isWaiting {
-                            Image(systemName: "clock")
-                        } else if movie.monitored {
-                            Image(systemName: "xmark").symbolVariant(.circle)
-                        }
-                    }.font(.caption)
-                    Text(movie.monitored ? "Monitored" : "Unmonitored").font(.footnote)
-                }.foregroundStyle(.secondary).opacity(0.8)
-            }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+        case .expanded:
+            VStack {
+                poster
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contextMenu {
+                        MovieContextMenu(movie: movie)
+                    } preview: {
+                        poster.frame(width: 300, height: 450)
+                    }
+                    .background(.secondarySystemBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                Group {
+                    Text(movie.title).font(.footnote).fontWeight(.medium)
+                    HStack(spacing: 4) {
+                        Group {
+                            if movie.isDownloaded {
+                                Image(systemName: "checkmark").symbolVariant(.circle.fill)
+                            } else if movie.isWaiting {
+                                Image(systemName: "clock")
+                            } else if movie.monitored {
+                                Image(systemName: "xmark").symbolVariant(.circle)
+                            }
+                        }.font(.caption)
+                        Text(movie.monitored ? "Monitored" : "Unmonitored").font(.footnote)
+                    }.foregroundStyle(.secondary).opacity(0.8)
+                }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+            }
         }
     }
 

--- a/Ruddarr/Views/Movies/MovieGridItem.swift
+++ b/Ruddarr/Views/Movies/MovieGridItem.swift
@@ -4,20 +4,21 @@ struct MovieGridItem: View {
     var movie: Movie
 
     var body: some View {
-        poster
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contextMenu {
-                MovieContextMenu(movie: movie)
-            } preview: {
-                poster.frame(width: 300, height: 450)
-            }
-            .background(.secondarySystemBackground)
-            .overlay(alignment: .bottom) {
-                if movie.exists {
-                    posterOverlay
+        VStack {
+            poster
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contextMenu {
+                    MovieContextMenu(movie: movie)
+                } preview: {
+                    poster.frame(width: 300, height: 450)
                 }
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+                .background(.secondarySystemBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            Group {
+                Text(movie.title).font(.footnote).fontWeight(.medium)
+                Text(movie.monitored ? "Monitored" : "Unmonitored").font(.footnote).foregroundStyle(.secondary)
+            }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+        }
     }
 
     var poster: some View {

--- a/Ruddarr/Views/Movies/MovieGridItem.swift
+++ b/Ruddarr/Views/Movies/MovieGridItem.swift
@@ -16,7 +16,18 @@ struct MovieGridItem: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
             Group {
                 Text(movie.title).font(.footnote).fontWeight(.medium)
-                Text(movie.monitored ? "Monitored" : "Unmonitored").font(.footnote).foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    Group {
+                        if movie.isDownloaded {
+                            Image(systemName: "checkmark").symbolVariant(.circle.fill)
+                        } else if movie.isWaiting {
+                            Image(systemName: "clock")
+                        } else if movie.monitored {
+                            Image(systemName: "xmark").symbolVariant(.circle)
+                        }
+                    }.font(.caption)
+                    Text(movie.monitored ? "Monitored" : "Unmonitored").font(.footnote)
+                }.foregroundStyle(.secondary).opacity(0.8)
             }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
         }
     }

--- a/Ruddarr/Views/Series/SeriesGridItem.swift
+++ b/Ruddarr/Views/Series/SeriesGridItem.swift
@@ -4,18 +4,21 @@ struct SeriesGridItem: View {
     var series: Series
 
     var body: some View {
-        poster
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contextMenu {
-                SeriesContextMenu(series: series)
-            } preview: {
-                poster.frame(width: 300, height: 450)
-            }
-            .background(.secondarySystemBackground)
-            .overlay(alignment: .bottom) {
-                posterOverlay
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+        VStack {
+            poster
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contextMenu {
+                    SeriesContextMenu(series: series)
+                } preview: {
+                    poster.frame(width: 300, height: 450)
+                }
+                .background(.secondarySystemBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            Group {
+                Text(series.title).font(.footnote).fontWeight(.medium)
+                Text(series.monitored ? "Monitored" : "Unmonitored").font(.footnote).foregroundStyle(.secondary)
+            }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+        }
     }
 
     var poster: some View {

--- a/Ruddarr/Views/Series/SeriesGridItem.swift
+++ b/Ruddarr/Views/Series/SeriesGridItem.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 struct SeriesGridItem: View {
+    @EnvironmentObject var settings: AppSettings
     var series: Series
 
     var body: some View {
-        VStack {
+        switch settings.layout {
+        case .compact:
             poster
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contextMenu {
@@ -13,26 +15,41 @@ struct SeriesGridItem: View {
                     poster.frame(width: 300, height: 450)
                 }
                 .background(.secondarySystemBackground)
+                .overlay(alignment: .bottom) {
+                    posterOverlay
+                }
                 .clipShape(RoundedRectangle(cornerRadius: 10))
-            Group {
-                Text(series.title).font(.footnote).fontWeight(.medium)
-                HStack(spacing: 4) {
-                    Group {
-                        if series.isDownloaded {
-                            Image(systemName: "checkmark").symbolVariant(.circle.fill)
-                        } else if series.isWaiting {
-                            Image(systemName: "clock")
-                        } else if series.percentOfEpisodes < 100 {
-                            if series.episodeFileCount > 0 {
-                                Image(systemName: "checkmark.circle.trianglebadge.exclamationmark")
-                            } else if series.monitored {
-                                Image(systemName: "xmark").symbolVariant(.circle)
+        case .expanded:
+            VStack {
+                poster
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contextMenu {
+                        SeriesContextMenu(series: series)
+                    } preview: {
+                        poster.frame(width: 300, height: 450)
+                    }
+                    .background(.secondarySystemBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                Group {
+                    Text(series.title).font(.footnote).fontWeight(.medium)
+                    HStack(spacing: 4) {
+                        Group {
+                            if series.isDownloaded {
+                                Image(systemName: "checkmark").symbolVariant(.circle.fill)
+                            } else if series.isWaiting {
+                                Image(systemName: "clock")
+                            } else if series.percentOfEpisodes < 100 {
+                                if series.episodeFileCount > 0 {
+                                    Image(systemName: "checkmark.circle.trianglebadge.exclamationmark")
+                                } else if series.monitored {
+                                    Image(systemName: "xmark").symbolVariant(.circle)
+                                }
                             }
-                        }
-                    }.font(.caption)
-                    Text(series.monitored ? "Monitored" : "Unmonitored").font(.footnote)
-                }.foregroundStyle(.secondary).opacity(0.8)
-            }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+                        }.font(.caption)
+                        Text(series.monitored ? "Monitored" : "Unmonitored").font(.footnote)
+                    }.foregroundStyle(.secondary).opacity(0.8)
+                }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+            }
         }
     }
 

--- a/Ruddarr/Views/Series/SeriesGridItem.swift
+++ b/Ruddarr/Views/Series/SeriesGridItem.swift
@@ -16,7 +16,22 @@ struct SeriesGridItem: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
             Group {
                 Text(series.title).font(.footnote).fontWeight(.medium)
-                Text(series.monitored ? "Monitored" : "Unmonitored").font(.footnote).foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    Group {
+                        if series.isDownloaded {
+                            Image(systemName: "checkmark").symbolVariant(.circle.fill)
+                        } else if series.isWaiting {
+                            Image(systemName: "clock")
+                        } else if series.percentOfEpisodes < 100 {
+                            if series.episodeFileCount > 0 {
+                                Image(systemName: "checkmark.circle.trianglebadge.exclamationmark")
+                            } else if series.monitored {
+                                Image(systemName: "xmark").symbolVariant(.circle)
+                            }
+                        }
+                    }.font(.caption)
+                    Text(series.monitored ? "Monitored" : "Unmonitored").font(.footnote)
+                }.foregroundStyle(.secondary).opacity(0.8)
             }.frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
         }
     }

--- a/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
+++ b/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
@@ -15,6 +15,7 @@ struct SettingsPreferencesSection: View {
             appearancePicker
             themePicker
             iconPicker
+            layoutPicker
 
             if ![.unknown, .notSubscribed].contains(subscriptionStatus) {
                 manageSubscription
@@ -96,6 +97,25 @@ struct SettingsPreferencesSection: View {
                     .frame(width: appIconSize, height: appIconSize)
                     .clipShape(.rect(cornerRadius: (10 / 57) * appIconSize))
             }
+        }
+    }
+    
+    var layoutPicker: some View {
+        Picker(selection: $settings.layout) {
+            ForEach(ViewLayout.allCases) { layout in
+                Text(layout.label)
+            }
+        } label: {
+            Label {
+                Text("Grid Layout")
+            } icon: {
+                Image(systemName: "rectangle.grid.1x2")
+                    .foregroundStyle(Color(.monochrome))
+            }
+        }
+        .tint(.secondary)
+        .onChange(of: settings.layout) {
+            dependencies.router.reset()
         }
     }
 


### PR DESCRIPTION
#### Summary
Removes the poster overlay in Movies and Series tabs in favor of displaying the movie/series title, download and monitor status below the poster. This aims to provide more visual context when scanning through movie/series items and reduces clutter atop the poster art.

##### Movies
| Before | After |
| --- | --- |
| <img src="https://github.com/ruddarr/app/assets/78137/75d90830-af22-4d50-a320-f9410f85af67" /> | <img src="https://github.com/ruddarr/app/assets/78137/c4e33dd4-4ed5-46b9-8da8-1741b9ffd220" /> |

##### Series
| Before | After |
| --- | --- |
| <img src="https://github.com/ruddarr/app/assets/78137/a9cc9483-54cb-4985-98ae-ea948a52d311" /> | <img src="https://github.com/ruddarr/app/assets/78137/c3f6d5f8-ccee-44b9-bb28-26dcedf262c2" /> |
