### PR TITLE
iOS 18 features

### DIFF
--- a/Ruddarr/Services/Intents.swift
+++ b/Ruddarr/Services/Intents.swift
@@ -109,3 +109,32 @@ struct AddSeriesIntent: AppIntent {
         return .result()
     }
 }
+
+// TODO: reevaluate with iOS 18
+// https://developer.apple.com/documentation/appintents/acceleratingappinteractionswithappintents
+
+// TODO: needs universal search page...
+// TODO: Set `CoreSpotlightContinuation` to `YES`
+
+@available(iOS 18.0, macOS 15.0, *)
+@AssistantIntent(schema: .system.search)
+struct SystemSearchIntent: AppIntent {
+   static let searchScopes: [StringSearchScope] = [.movies, .tv]
+
+   @Parameter(title: "Criteria")
+   var criteria: StringSearchCriteria
+
+   @MainActor
+   func perform() async throws -> some IntentResult {
+       dependencies.router.moviesPath = .init()
+       dependencies.router.selectedTab = .movies
+
+       try? await Task.sleep(nanoseconds: 50_000_000)
+
+       dependencies.router.moviesPath.append(
+           MoviesPath.search(criteria.term.trimmingCharacters(in: .whitespaces))
+       )
+
+       return .result()
+   }
+}

--- a/Ruddarr/Utilities/Binding.swift
+++ b/Ruddarr/Utilities/Binding.swift
@@ -25,15 +25,13 @@ extension Binding {
 
 extension Binding where Value: OptionalProtocol {
     var unwrapped: Binding<Value.Wrapped>? {
-        guard var wrappedValue = self.wrappedValue.wrappedValue else {
+        guard let firstValue = self.wrappedValue.wrappedValue else {
             return nil
         }
-
         return .init {
-            wrappedValue
+            self.wrappedValue.wrappedValue ?? firstValue
         } set: {
-            wrappedValue = $0
-            self.wrappedValue.wrappedValue = wrappedValue
+            self.wrappedValue.wrappedValue = $0
         }
     }
 }


### PR DESCRIPTION
- New icons
- Fix Swift 6 warning
- `@AssistantIntent(schema: .system.search)`

```swift
SiriTipView(intent: OpenFavorites(), isVisible: $displaySiriTip)
```

## Use `NSAppIconActionTintColorName` and `NSAppIconCompletingColorNames`
- https://github.com/OmChachad/Linkeeper/blob/a605d72e6d73116715c36bb969f6f2338f88e393/Linkeeper/Info.plist#L5-L17
- https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleicons/cfbundleprimaryicon/nsappiconactiontintcolorname

## Consider using `OpenIntent` for some?
- https://developer.apple.com/videos/play/wwdc2024/10176/
- Use this intent to open both dynamic items such as AppEntity and static items such as an AppEnum with voice commands; for example, “Open ‘Vacation Ideas’” or “Open bookmarks”.

https://developer.apple.com/documentation/appintents/integrating-your-app-with-siri-and-apple-intelligence