### PR TITLE
Use build number as prefix in Spotlight.calculateChecksum

### DIFF
--- a/Ruddarr/Services/Spotlight.swift
+++ b/Ruddarr/Services/Spotlight.swift
@@ -123,7 +123,8 @@ class Spotlight {
     }
 
     func calculateChecksum(_ string: String) -> String {
-        let data = string.data(using: .utf8) ?? Data()
+        let buildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        let data = (buildVersion ?? "" + string).data(using: .utf8) ?? Data()
 
         let checksum = data.withUnsafeBytes {
             crc32(0, $0.bindMemory(to: Bytef.self).baseAddress, uInt(data.count))


### PR DESCRIPTION
Fixes #346