### PR TITLE
Add Locations Disk Space to Instances

### DIFF
--- a/Ruddarr.xcodeproj/project.pbxproj
+++ b/Ruddarr.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		798010BD2B6268D200BBC056 /* RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798010BC2B6268D200BBC056 /* RawRepresentable.swift */; };
 		798010BF2B6268DE00BBC056 /* MovieSort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798010BE2B6268DE00BBC056 /* MovieSort.swift */; };
 		79B761CB2B7115EC001DD30E /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B761CA2B7115EC001DD30E /* Toast.swift */; };
+		96B6EB412D709375009C8ED2 /* locations-disk-space.json in Resources */ = {isa = PBXBuildFile; fileRef = 96B6EB402D709375009C8ED2 /* locations-disk-space.json */; };
 		BB01B1F42B6465730025FAF4 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB01B1F32B6465730025FAF4 /* View.swift */; };
 		BB035A442C1D3B71005DFD45 /* Spotlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB035A432C1D3B71005DFD45 /* Spotlight.swift */; };
 		BB05C9052B86D0EC009B6444 /* Languages.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB05C9042B86D0EC009B6444 /* Languages.swift */; };
@@ -236,6 +237,7 @@
 		798010BC2B6268D200BBC056 /* RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawRepresentable.swift; sourceTree = "<group>"; };
 		798010BE2B6268DE00BBC056 /* MovieSort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieSort.swift; sourceTree = "<group>"; };
 		79B761CA2B7115EC001DD30E /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+		96B6EB402D709375009C8ED2 /* locations-disk-space.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "locations-disk-space.json"; sourceTree = "<group>"; };
 		BB01B1F32B6465730025FAF4 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		BB035A432C1D3B71005DFD45 /* Spotlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spotlight.swift; sourceTree = "<group>"; };
 		BB05C9042B86D0EC009B6444 /* Languages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Languages.swift; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				BB8B3DF32B617FE800B80E2D /* root-folders.json */,
 				BB7602742B62027C006E5A1F /* quality-profiles.json */,
 				BB94F1BA2B7E8A190050F6A0 /* notifications.json */,
+				96B6EB402D709375009C8ED2 /* locations-disk-space.json */,
 				BBF583C12BACBE1400AFA7FB /* calendar-movies.json */,
 				BBF583C32BACBE5000AFA7FB /* calendar-episodes.json */,
 				BB8100092CD5976B00499666 /* radarr-history.json */,
@@ -920,6 +923,7 @@
 			files = (
 				BB0BEA8F2BE59640004DBFE6 /* series-episodes.json in Resources */,
 				BB644FCF2B8538A3007C7AD5 /* ci_post_xcodebuild.sh in Resources */,
+				96B6EB412D709375009C8ED2 /* locations-disk-space.json in Resources */,
 				BB94F1BB2B7E8A190050F6A0 /* notifications.json in Resources */,
 				BBA733692BB6070900A5022B /* movie-extra-files.json in Resources */,
 				BBF583C42BACBE5000AFA7FB /* calendar-episodes.json in Resources */,

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -50,6 +50,8 @@ struct API {
     var createNotification: (InstanceNotification, Instance) async throws -> InstanceNotification
     var updateNotification: (InstanceNotification, Instance) async throws -> InstanceNotification
     var deleteNotification: (InstanceNotification, Instance) async throws -> Empty
+    
+    var fetchLocationsDiskSpace: (Instance) async throws -> [InstanceLocationDiskSpace]
 }
 
 // swiftlint:disable file_length
@@ -344,6 +346,10 @@ extension API {
                 .appending(path: String(model.id ?? 0))
 
             return try await request(method: .delete, url: url, headers: instance.auth)
+        }, fetchLocationsDiskSpace: { instance in
+            let url = URL(string: instance.url)!
+                .appending(path: "/api/v3/diskspace")
+            return try await request(method: .get, url: url, headers: instance.auth)
         })
     }
 

--- a/Ruddarr/Dependencies/API/DummyAPI.swift
+++ b/Ruddarr/Dependencies/API/DummyAPI.swift
@@ -177,6 +177,10 @@ extension API {
             try await Task.sleep(nanoseconds: 2_000_000_000)
 
             return Empty()
+        }, fetchLocationsDiskSpace: { _ in
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+
+            return loadPreviewData(filename: "locations-disk-space")
         })
     }
 }

--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -1141,6 +1141,16 @@
         }
       }
     },
+    "Disk Space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disk Space"
+          }
+        }
+      }
+    },
     "Download" : {
       "localizations" : {
         "en" : {
@@ -2575,6 +2585,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No Internet Connection"
+          }
+        }
+      }
+    },
+    "No locations found" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No locations found"
           }
         }
       }

--- a/Ruddarr/Models/Instances/Instance.swift
+++ b/Ruddarr/Models/Instances/Instance.swift
@@ -108,6 +108,13 @@ struct InstanceQualityProfile: Identifiable, Equatable, Codable {
     let name: String
 }
 
+struct InstanceLocationDiskSpace: Identifiable, Equatable, Codable {
+    var id: String { path }
+    let path: String
+    let freeSpace: Int64
+    let totalSpace: Int64
+}
+
 extension Instance {
     static var radarrVoid: Self {
         .init(

--- a/Ruddarr/Preview Content/locations-disk-space.json
+++ b/Ruddarr/Preview Content/locations-disk-space.json
@@ -1,0 +1,20 @@
+[
+  {
+    "path": "/",
+    "label": "",
+    "freeSpace": 67114201088,
+    "totalSpace": 105089261568
+  },
+  {
+    "path": "/config",
+    "label": "",
+    "freeSpace": 67114201088,
+    "totalSpace": 105089261568
+  },
+  {
+    "path": "/downloads",
+    "label": "",
+    "freeSpace": 1353742012416,
+    "totalSpace": 5905800814592
+  }
+]

--- a/Ruddarr/Utilities/Helpers.swift
+++ b/Ruddarr/Utilities/Helpers.swift
@@ -236,3 +236,31 @@ class PreviewData {
         fatalError("Invalid preview data path: \(name)")
     }
 }
+
+extension BinaryInteger {
+    /// Converts a byte count into a string with the unit (B, KB, MB, GB, TB, PB)
+    /// - Parameter decimalPlaces: Number of decimal places to round to (default: 1)
+    /// - Returns: A formatted string with the appropriate byte unit (5 TB)
+    func formatBytes(decimalPlaces: Int = 1) -> String {
+        let units = ["B", "KB", "MB", "GB", "TB", "PB"]
+        if self == 0 {
+            return "0 B"
+        }
+        
+        let bytes = abs(Int(self))
+        let exp = Int(log(Double(bytes)) / log(1024.0))
+        let unitIndex = min(exp, units.count - 1)
+        let value = Double(bytes) / pow(1024.0, Double(unitIndex))
+        
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = decimalPlaces
+        formatter.minimumFractionDigits = value.truncatingRemainder(dividingBy: 1) == 0 ? 0 : decimalPlaces
+        
+        if let formattedValue = formatter.string(from: NSNumber(value: value)) {
+            return "\(formattedValue) \(units[unitIndex])"
+        } else {
+            return String(format: "%.\(decimalPlaces)f %@", value, units[unitIndex])
+        }
+    }
+}

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -73,6 +73,7 @@ struct EpisodeRow: View {
         Button {
             Task { await toggleMonitor() }
         } label: {
+            
             if instance.episodes.isMonitoring == episode.id {
                 ProgressView().tint(.secondary)
             } else {


### PR DESCRIPTION
Closes #278 .

- New endpoint to fetch locations disk space
- Show the disk pace per location
- Add loading, empty/error and loaded states

Please, add any feedback or criticism. Also I can include more metadata.

| Loading | Empty/Error | Loaded | Long Path | Sonarr |
| --- | --- | --- | --- | --- |
| ![Image](https://github.com/user-attachments/assets/01e4596d-b5e8-4dae-90a7-a4b6e37e5934) | ![Image](https://github.com/user-attachments/assets/367328cb-784a-449b-bea2-90331a8c2625) | ![Image](https://github.com/user-attachments/assets/6bb6fc47-caf3-4431-b86f-aa4ea6908264) | ![Image](https://github.com/user-attachments/assets/ca5b79b0-06b8-408c-a2d6-cf5059fa4aac) |  ![Image](https://github.com/user-attachments/assets/88b4b15e-8c19-45c5-9b97-9089913227a0) |