### PR TITLE
Calendar View Tweaks

### DIFF
--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -5,6 +5,7 @@ struct CalendarView: View {
 
     @State private var scrollView: ScrollViewProxy?
     @State private var initializationError: API.Error?
+    @State private var isContentReady: Bool = false
 
     @AppStorage("calendarMonitored", store: dependencies.store) private var onlyMonitored: Bool = false
 
@@ -44,6 +45,7 @@ struct CalendarView: View {
                                     media(for: timestamp, date: date)
                                 }
                             }
+                            .opacity(isContentReady ? 1 : 0)
 
                             Group {
                                 if calendar.isLoadingFuture {
@@ -74,6 +76,7 @@ struct CalendarView: View {
                 if calendar.instances != settings.instances {
                     calendar.reset()
                     calendar.instances = settings.instances
+                    isContentReady = false
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .scrollToToday)) { _ in
@@ -185,7 +188,9 @@ struct CalendarView: View {
         guard firstLoad else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            scrollView?.scrollTo(calendar.today(), anchor: UnitPoint(x: 0, y: 0.02))
+            scrollTo(calendar.today())
+
+            isContentReady = true
         }
     }
 

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -77,7 +77,7 @@ struct CalendarView: View {
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .scrollToToday)) { _ in
-                withAnimation(.smooth) {
+                withAnimation(.interactiveSpring) {
                     scrollTo(calendar.today())
                 }
             }
@@ -185,9 +185,7 @@ struct CalendarView: View {
         guard firstLoad else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            withAnimation(.interactiveSpring) {
-                scrollTo(calendar.today())
-            }
+            scrollView?.scrollTo(calendar.today(), anchor: UnitPoint(x: 0, y: 0.02))
         }
     }
 
@@ -198,7 +196,8 @@ struct CalendarView: View {
     }
 
     func scrollTo(_ timestamp: TimeInterval) {
-        scrollView?.scrollTo(timestamp, anchor: .center)
+        let topPadding = UnitPoint(x: 0, y: 0.02)
+        scrollView?.scrollTo(timestamp, anchor: topPadding)
     }
 
     func media(for timestamp: TimeInterval, date: Date) -> some View {
@@ -223,8 +222,10 @@ struct CalendarView: View {
     var todayButton: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
             Button("Today") {
-                withAnimation(.smooth) {
-                    scrollTo(calendar.today())
+                DispatchQueue.main.async {
+                    withAnimation(.interactiveSpring) {
+                        self.scrollTo(self.calendar.today())
+                    }
                 }
             }
         }


### PR DESCRIPTION
Tapping Today button now works even if there's still scroll inertia.

The scroll-to-today position now puts today's date at the top of the screen, with a little padding for comfort.

The initial display of the Calendar tab now goes straight to today's date without a visible scroll.