### PR TITLE
Add timeout to addMovie and addSeries API calls

### DIFF
--- a/Ruddarr/Dependencies/API/API+Live.swift
+++ b/Ruddarr/Dependencies/API/API+Live.swift
@@ -49,7 +49,7 @@ extension API {
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/movie")
 
-            return try await request(method: .post, url: url, headers: instance.auth, body: movie)
+            return try await request(method: .post, url: url, headers: instance.auth, body: movie, timeout: instance.timeout(.slow))
         }, updateMovie: { movie, moveFiles, instance in
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/movie/editor")
@@ -130,7 +130,7 @@ extension API {
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/series")
 
-            return try await request(method: .post, url: url, headers: instance.auth, body: series)
+            return try await request(method: .post, url: url, headers: instance.auth, body: series, timeout: instance.timeout(.slow))
         }, pushSeries: { series, instance in
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/series")


### PR DESCRIPTION
## Summary

The `addMovie` and `addSeries` functions in `API+Live.swift` were missing the `timeout` parameter that other similar operations include (e.g., `fetchMovies`, `lookupSeries`, `downloadRelease`).

This could cause the app to appear stuck when adding movies/series, particularly on slower networks, as there's no timeout to fail gracefully.

Fixes #565

## Changes

- Added `timeout: instance.timeout(.slow)` to `addMovie`
- Added `timeout: instance.timeout(.slow)` to `addSeries`

## Testing

The `.slow` timeout is consistent with other similar read/write operations in the codebase.