### PR TITLE
Add macOS alternatives for settings URL deep links

### DIFF
--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -4881,7 +4881,7 @@
       }
     },
     "System Settings" : {
-      "comment" : "Settings app name\niOS path",
+      "comment" : "Settings app name",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -4892,12 +4892,23 @@
       }
     },
     "System Settings > Notifications > %@" : {
-      "comment" : "macOS path",
+      "comment" : "macOS notifications path",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "System Settings > Notifications > %@"
+          }
+        }
+      }
+    },
+    "System Settings > Privacy & Security > Local Network" : {
+      "comment" : "macOS local network path",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Settings > Privacy & Security > Local Network"
           }
         }
       }

--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -1103,6 +1103,16 @@
         }
       }
     },
+    "Contribute on GitHub" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contribute on GitHub"
+          }
+        }
+      }
+    },
     "Copy Link" : {
       "localizations" : {
         "en" : {

--- a/Ruddarr/Views/Settings/InstanceView+Notifications.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Notifications.swift
@@ -3,7 +3,11 @@ import CloudKit
 
 extension InstanceView {
     var notificationPath: String {
-        String(format: "[%@](#link)", String(localized: "System Settings"))
+        #if os(macOS)
+            return String(format: "\"%@\"", String(localized: "System Settings > Notifications > \(Ruddarr.name)", comment: "macOS path"))
+        #else
+            return String(format: "[%@](#link)", String(localized: "System Settings", comment: "iOS path"))
+        #endif
     }
 
     var enableNotifications: some View {

--- a/Ruddarr/Views/Settings/InstanceView+Notifications.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Notifications.swift
@@ -3,11 +3,7 @@ import CloudKit
 
 extension InstanceView {
     var notificationPath: String {
-        #if os(macOS)
-            return String(format: "\"%@\"", String(localized: "System Settings > Notifications > \(Ruddarr.name)", comment: "macOS path"))
-        #else
-            return String(format: "[%@](#link)", String(localized: "System Settings", comment: "iOS path"))
-        #endif
+        String(format: "[%@](#link)", String(localized: "System Settings"))
     }
 
     var enableNotifications: some View {
@@ -17,7 +13,11 @@ extension InstanceView {
         )
 
         return Text(text.toMarkdown()).environment(\.openURL, .init { _ in
-            #if os(iOS)
+            #if os(macOS)
+                if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
+                    NSWorkspace.shared.open(url)
+                }
+            #else
                 if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
                     UIApplication.shared.open(url)
                 }
@@ -34,7 +34,11 @@ extension InstanceView {
         )
 
         return Text(text.toMarkdown()).environment(\.openURL, .init { _ in
-            #if os(iOS)
+            #if os(macOS)
+                if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
+                    NSWorkspace.shared.open(url)
+                }
+            #else
                 if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
                     UIApplication.shared.open(url)
                 }

--- a/Ruddarr/Views/Settings/InstanceView+Notifications.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Notifications.swift
@@ -4,7 +4,6 @@ import CloudKit
 extension InstanceView {
     var notificationPath: String {
         #if os(macOS)
-            // TODO: link missing
             return String(format: "[%@](#link)", String(localized: "System Settings > Notifications > \(Ruddarr.name)", comment: "macOS notifications path"))
         #else
             return String(format: "[%@](#link)", String(localized: "System Settings", comment: "Settings app name"))

--- a/Ruddarr/Views/Settings/InstanceView+Notifications.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Notifications.swift
@@ -4,9 +4,10 @@ import CloudKit
 extension InstanceView {
     var notificationPath: String {
         #if os(macOS)
-            return String(format: "\"%@\"", String(localized: "System Settings > Notifications > \(Ruddarr.name)", comment: "macOS path"))
+            // TODO: link missing
+            return String(format: "[%@](#link)", String(localized: "System Settings > Notifications > \(Ruddarr.name)", comment: "macOS notifications path"))
         #else
-            return String(format: "[%@](#link)", String(localized: "System Settings", comment: "iOS path"))
+            return String(format: "[%@](#link)", String(localized: "System Settings", comment: "Settings app name"))
         #endif
     }
 

--- a/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
+++ b/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
@@ -20,9 +20,7 @@ struct SettingsPreferencesSection: View {
         } header: {
             Text("Preferences")
         } footer: {
-            #if os(iOS)
-                footer
-            #endif
+            footer
         }
         .subscriptionStatusTask(
             for: Subscription.group,
@@ -118,7 +116,11 @@ struct SettingsPreferencesSection: View {
         let text = String(localized: "Preferred language and other app-related settings can be configured in the [System Settings](#link).")
 
         return Text(text.toMarkdown()).environment(\.openURL, .init { _ in
-            #if os(iOS)
+            #if os(macOS)
+                if let url = URL(string: "x-apple.systempreferences:com.apple.Localization-Settings") {
+                    NSWorkspace.shared.open(url)
+                }
+            #else
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url)
                 }

--- a/Ruddarr/Views/SettingsView.swift
+++ b/Ruddarr/Views/SettingsView.swift
@@ -105,8 +105,8 @@ struct SettingsView: View {
         #endif
 
         let text = String(
-            format: String(localized: "Local network access must be granted in [%@](#link) to connect to instances using private IP addresses."),
-            settingsPath
+            format: String(localized: "Local network access must be granted in %@ to connect to instances using private IP addresses."),
+            "[\(settingsPath)](#link)"
         )
 
         var markdown = text.toMarkdown()

--- a/Ruddarr/Views/SettingsView.swift
+++ b/Ruddarr/Views/SettingsView.swift
@@ -98,18 +98,26 @@ struct SettingsView: View {
     }
 
     var localNetworkWarning: some View {
-        let settingsPath = String(
-            format: "[%@](#link)",
-            String(localized: "System Settings", comment: "Settings app name")
-        )
+        #if os(macOS)
+            let settingsPath = String(localized: "System Settings > Privacy & Security > Local Network", comment: "macOS local network path")
+        #else
+            let settingsPath = String(localized: "System Settings", comment: "Settings app name")
+        #endif
 
         let text = String(
-            format: String(localized: "Local network access must be granted in %@ to connect to instances using private IP addresses."),
+            format: String(localized: "Local network access must be granted in [%@](#link) to connect to instances using private IP addresses."),
             settingsPath
         )
 
-        return Text(text.toMarkdown())
+        var markdown = text.toMarkdown()
+
+        for run in markdown.runs where run.link != nil {
+            markdown[run.range].underlineStyle = .single
+        }
+
+        return Text(markdown)
             .foregroundStyle(.orange)
+            .tint(.orange)
             .environment(\.openURL, .init { _ in
                 #if os(macOS)
                     if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocalNetwork") {


### PR DESCRIPTION
## Summary

- **Notification settings**: On macOS, tapping the "System Settings" link now opens `System Settings > Notifications` via `x-apple.systempreferences:com.apple.Notifications-Settings` instead of being a no-op
- **Language/preferences settings**: On macOS, tapping the "System Settings" link now opens `System Settings > Language & Region` via `x-apple.systempreferences:com.apple.Localization-Settings` instead of being a no-op
- **Clickable link on macOS**: `notificationPath` now renders as a clickable markdown link on macOS (previously was plain quoted text with no action)
- **Footer visible on macOS**: The preferences section footer with the System Settings link is now shown on macOS too (was gated behind `#if os(iOS)`)

## Test plan

- [ ] On macOS, go to instance notification settings when notifications are disabled — tap "System Settings" link and verify it opens the Notifications pane
- [ ] On macOS, go to Settings > Preferences — verify the footer is visible and tapping "System Settings" opens Language & Region
- [ ] On iOS, verify existing behavior is unchanged for both notification and preferences settings links

https://claude.ai/code/session_01WonMy2SJayWdGtAmPDkgBN