### PR TITLE
Add IPv6 and additional IPv4 private address range detection

### DIFF
--- a/Ruddarr/Services/Network.swift
+++ b/Ruddarr/Services/Network.swift
@@ -45,6 +45,29 @@ actor NetworkMonitor {
 }
 
 func isPrivateIpAddress(_ ipAddress: String) -> Bool {
+    // IPv6
+    if IPv6Address(ipAddress) != nil {
+        let normalized = ipAddress.lowercased()
+
+        // ::1 (loopback)
+        if normalized == "::1" || normalized == "0000:0000:0000:0000:0000:0000:0000:0001" {
+            return true
+        }
+
+        // fe80::/10 (link-local)
+        if normalized.hasPrefix("fe80:") {
+            return true
+        }
+
+        // fd00::/8 (unique local address)
+        if normalized.hasPrefix("fd") {
+            return true
+        }
+
+        return false
+    }
+
+    // IPv4
     guard IPv4Address(ipAddress) != nil else {
         return false
     }
@@ -55,7 +78,7 @@ func isPrivateIpAddress(_ ipAddress: String) -> Bool {
         return false
     }
 
-    // 127.0.0.0 - 127.255.255.255 (loopback address)
+    // 127.0.0.0 - 127.255.255.255 (loopback)
     if first == 127 {
         return true
     }
@@ -72,6 +95,16 @@ func isPrivateIpAddress(_ ipAddress: String) -> Bool {
 
     // 192.168.0.0 - 192.168.255.255 (private)
     if first == 192 && second == 168 {
+        return true
+    }
+
+    // 169.254.0.0 - 169.254.255.255 (link-local)
+    if first == 169 && second == 254 {
+        return true
+    }
+
+    // 100.64.0.0 - 100.127.255.255 (CGNAT / shared address space)
+    if first == 100 && (second >= 64 && second <= 127) {
         return true
     }
 


### PR DESCRIPTION
## Summary
Enhanced the `isPrivateIpAddress()` function to properly detect IPv6 private addresses and added support for additional IPv4 private address ranges that were previously missing.

## Key Changes
- **IPv6 Support**: Added detection for IPv6 private address ranges:
  - `::1` (loopback)
  - `fe80::/10` (link-local addresses)
  - `fd00::/8` (unique local addresses)
  
- **Additional IPv4 Ranges**: Added detection for two previously unsupported private IPv4 ranges:
  - `169.254.0.0 - 169.254.255.255` (link-local/APIPA addresses)
  - `100.64.0.0 - 100.127.255.255` (CGNAT/shared address space)

- **Minor Improvements**: Updated comment for loopback address from "loopback address" to "loopback" for consistency

## Implementation Details
- IPv6 validation uses the `IPv6Address` initializer to verify format before checking specific ranges
- IPv6 addresses are normalized to lowercase for consistent prefix matching
- IPv4 range checks follow the existing pattern of comparing octets
- The function maintains backward compatibility while expanding coverage of private address ranges

https://claude.ai/code/session_01WFYsfgzbsW5U33R82c8mqH