### PR TITLE
Switch macOS CI from build to test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
                 action: test
               - name: macOS
                 platform: "macOS"
-                action: build
+                action: test
 
         steps:
           - name: Checkout repository


### PR DESCRIPTION
The macOS job was using `xcodebuild build` which tries to produce a
fully-signed app bundle — this fails in CI due to macOS code signing
and entitlement requirements. Switching to `xcodebuild test` runs the
unit tests via a test runner that doesn't require the full signing setup,
matching how iOS tests are run and how tests are verified locally.

https://claude.ai/code/session_016rJaZnQUkwZa4vkQYjsaaS