### PR TITLE
Update version to 1.8.1 and refresh What's New features

### DIFF
--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -71,33 +71,28 @@ struct Ruddarr: App {
 }
 
 extension WhatsNew {
-    static let version: String = "1.8.0"
+    static let version: String = "1.8.1"
 
     static let features: [WhatsNewFeature] = [
         .init(
-            image: "flame",
-            title: "Media Discovery",
-            subtitle: "Discover popular movies and series when adding searching for new media."
+            image: "globe",
+            title: "New Translations",
+            subtitle: "Italian and Turkish translations have been added."
         ),
         .init(
-            image: "macwindow.and.pointer.arrow",
-            title: "macOS Beta",
-            subtitle: "Join the TestFlight for macOS from Settings and report any issues on Discord."
+            image: "eye.slash",
+            title: "Faded Unmonitored Items",
+            subtitle: "Items already in your library or calendar that are unmonitored now appear faded."
         ),
         .init(
-            image: "line.3.horizontal.decrease",
-            title: "Filter by Folder",
-            subtitle: "Filter media grids by root folders, how did we survive without this?"
-        ),
-        .init(
-            image: "network",
-            title: "Improved Networking",
-            subtitle: "Support connecting to insecure instances previously blocked by App Transport Security."
+            image: "film.stack",
+            title: "Dual Audio in Multi",
+            subtitle: "Releases with dual audio are now included in the \"Multi\" language filter."
         ),
         .init(
             image: "ladybug",
             title: "Fixes & Improvements",
-            subtitle: "Various small improvements and fixes, everything is a little better."
+            subtitle: "Various internal code improvements, bug fixes, and macOS refinements."
         ),
     ]
 }

--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -73,6 +73,8 @@ struct Ruddarr: App {
 extension WhatsNew {
     static let version: String = "1.8.1"
 
+    // Keep subtitles to around 72 characters:
+    // "------------------------------------------------------------------------"
     static let features: [WhatsNewFeature] = [
         .init(
             image: "globe",

--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -73,28 +73,27 @@ struct Ruddarr: App {
 extension WhatsNew {
     static let version: String = "1.8.1"
 
-    // Keep subtitles to around 72 characters:
-    // "------------------------------------------------------------------------"
+    // ----------------------------------------------------------------------------------------------⌄⌄⌄
     static let features: [WhatsNewFeature] = [
         .init(
             image: "globe",
-            title: "New Translations",
-            subtitle: "Italian and Turkish translations have been added."
+            title: "Translations",
+            subtitle: "Added Italian and Turkish translations. Removed Chinese translation."
         ),
         .init(
             image: "eye.slash",
-            title: "Faded Unmonitored Items",
-            subtitle: "Items already in your library or calendar that are unmonitored now appear faded."
+            title: "Faded Items",
+            subtitle: "Fade items in the calednar and discovery grid the app to idicate their status."
         ),
         .init(
             image: "film.stack",
             title: "Dual Audio in Multi",
-            subtitle: "Releases with dual audio are now included in the \"Multi\" language filter."
+            subtitle: "Releases with dual audio are now included in the Multilingual language filter."
         ),
         .init(
             image: "ladybug",
             title: "Fixes & Improvements",
-            subtitle: "Various internal code improvements, bug fixes, and macOS refinements."
+            subtitle: "Various internal code improvements, bug fixes, and refinements for macOS."
         ),
     ]
 }


### PR DESCRIPTION
## Summary
Updated the app version to 1.8.1 and refreshed the "What's New" feature list to highlight the latest improvements and additions in this release.

## Key Changes
- Bumped version from 1.8.0 to 1.8.1
- Replaced the "What's New" feature list with four new highlights:
  - **New Translations**: Added Italian and Turkish language support
  - **Faded Unmonitored Items**: Visual improvement showing unmonitored library/calendar items as faded
  - **Dual Audio in Multi**: Enhanced language filtering to include dual audio releases in the "Multi" filter
  - **Fixes & Improvements**: Updated description to reflect internal code improvements and macOS refinements

## Notable Details
The feature descriptions have been updated to accurately reflect the current release's improvements, with updated SF Symbol icons (globe, eye.slash, film.stack) to visually represent each feature.

https://claude.ai/code/session_01CaWhM4in4CnrbZKwJL5ANW