### PR TITLE
Sync instances to App Groups container for Share Extension

### DIFF
--- a/Ruddarr.xcodeproj/project.pbxproj
+++ b/Ruddarr.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 		BB8100092CD5976B00499666 /* radarr-history.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "radarr-history.json"; sourceTree = "<group>"; };
 		BB83AFA42CB2080C00349997 /* InstanceCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceCommand.swift; sourceTree = "<group>"; };
 		BB846F2E2E7DE1BC00E0A367 /* NotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationService.entitlements; sourceTree = "<group>"; };
+		CC5E00012F5A000100000020 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
 		BB865E602B83C11E00ADCEFE /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		BB89058A2E41359E0057C62B /* SeasonCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonCard.swift; sourceTree = "<group>"; };
 		BB89ABC52B756B91009FB62D /* MovieReleaseRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieReleaseRow.swift; sourceTree = "<group>"; };
@@ -645,6 +646,7 @@
 		CC5E00012F5A000100000004 /* ShareExtension */ = {
 			isa = PBXGroup;
 			children = (
+				CC5E00012F5A000100000020 /* ShareExtension.entitlements */,
 				CC5E00012F5A000100000003 /* Info.plist */,
 				CC5E00012F5A000100000002 /* ShareViewController.swift */,
 				CC5E00012F5A000100000012 /* ShareURLHandler.swift */,
@@ -1616,6 +1618,7 @@
 		CC5E00012F5A00010000000D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1652,6 +1655,7 @@
 		CC5E00012F5A00010000000E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Ruddarr/Ruddarr.entitlements
+++ b/Ruddarr/Ruddarr.entitlements
@@ -16,5 +16,9 @@
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.ruddarr</string>
+	</array>
 </dict>
 </plist>

--- a/Ruddarr/Services/AppSettings.swift
+++ b/Ruddarr/Services/AppSettings.swift
@@ -12,6 +12,20 @@ class AppSettings: ObservableObject {
         @CloudStorage("instances") var instances: [Instance] = []
     #endif
 
+    init() {
+        NotificationCenter.default.addObserver(
+            forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: NSUbiquitousKeyValueStore.default,
+            queue: .main
+        ) { [weak self] notification in
+            guard let keys = notification.userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String],
+                  keys.contains("instances") else { return }
+            Task { @MainActor [weak self] in
+                self?.syncInstancesToAppGroup()
+            }
+        }
+    }
+
     @AppStorage("icon", store: dependencies.store) var icon: AppIcon = .factory
     @AppStorage("theme", store: dependencies.store) var theme: Theme = .factory
     @AppStorage("appearance", store: dependencies.store) var appearance: Appearance = .automatic
@@ -77,6 +91,7 @@ extension AppSettings {
         }
 
         Queue.shared.instances = instances
+        syncInstancesToAppGroup()
     }
 
     func deleteInstance(_ instance: Instance) {
@@ -95,6 +110,13 @@ extension AppSettings {
         }
 
         Queue.shared.instances = instances
+        syncInstancesToAppGroup()
+    }
+
+    func syncInstancesToAppGroup() {
+        guard let data = try? JSONEncoder().encode(instances),
+              let defaults = UserDefaults(suiteName: "group.com.ruddarr") else { return }
+        defaults.set(data, forKey: "instances")
     }
 }
 

--- a/Ruddarr/Utilities/View.swift
+++ b/Ruddarr/Utilities/View.swift
@@ -85,6 +85,7 @@ private struct WithAppStateModifier: ViewModifier {
             .environment(SonarrInstance(sonarrInstance))
             .task {
                 Queue.shared.instances = settings.instances
+                settings.syncInstancesToAppGroup()
                 setSentryContext(for: "Configuration", settings.context())
                 await setSentryCloudKitContext()
             }

--- a/ShareExtension/README.md
+++ b/ShareExtension/README.md
@@ -34,7 +34,7 @@ in the main app (`RadarrInstance`/`SonarrInstance`, `AppSettings`,
 
 ## TODOs
 
-- [ ] Sync instances to App Groups shared container from the main app
+- [x] Sync instances to App Groups shared container from the main app
 - [x] Replace `AsyncImage` with NukeUI `LazyImage` (add Nuke dependency to extension target)
 - [ ] Deduplicate models/views by extracting shared code into a framework or Swift package
 - [x] Handle case when no instances are configured (show setup instructions)

--- a/ShareExtension/ShareExtension.entitlements
+++ b/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.ruddarr</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Enable the Share Extension to access the configured instances by syncing them to a shared App Groups container. This allows the Share Extension to read instance data from the main app without requiring direct access to the main app's UserDefaults.

## Key Changes
- **AppSettings**: Added initialization observer to listen for iCloud KeyValue Store changes and sync instances to App Groups when they change externally
- **AppSettings**: Added `syncInstancesToAppGroup()` method that encodes instances and writes them to the shared App Groups UserDefaults
- **AppSettings**: Call `syncInstancesToAppGroup()` whenever instances are added or deleted to keep the shared container in sync
- **Entitlements**: Added App Groups capability (`group.com.ruddarr`) to both main app and Share Extension targets
- **Build Configuration**: Added `CODE_SIGN_ENTITLEMENTS` setting to ShareExtension build targets
- **View**: Call `syncInstancesToAppGroup()` during app initialization to ensure Share Extension has access to instances on first launch

## Implementation Details
- Uses `UserDefaults(suiteName:)` with the `group.com.ruddarr` suite name to access the shared container
- Instances are encoded as JSON data before being stored in the shared UserDefaults
- The iCloud sync observer ensures instances are synced whenever they change on other devices
- Gracefully handles encoding failures with guard statements

https://claude.ai/code/session_01VsmqhzkysTDdfwKPpdt7Fb