### PR TITLE
Fix macOS notifications translations (again)

### DIFF
--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -17,11 +17,7 @@ class NotificationService: UNNotificationServiceExtension {
 
         self.contentHandler = contentHandler
 
-        #if os(macOS)
-            self.bestAttemptContent = UNMutableNotificationContent.resolvedContent(from: request.content)
-        #else
-            self.bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
-        #endif
+        self.bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
         if let bestAttemptContent = bestAttemptContent {
             if let attachment = request.attachment {
@@ -63,67 +59,5 @@ extension UNNotificationRequest {
         }
 
         return try? UNNotificationAttachment(identifier: posterHash, url: fileUrl)
-    }
-}
-
-
-extension UNMutableNotificationContent {
-    static func resolvedContent(from original: UNNotificationContent) -> UNMutableNotificationContent {
-        guard let aps = original.userInfo["aps"] as? [String: Any],
-              let alert = aps["alert"] as? [String: Any] else {
-            return (original.mutableCopy() as? UNMutableNotificationContent) ?? UNMutableNotificationContent()
-        }
-
-        let content = UNMutableNotificationContent()
-
-        content.title = resolveLocalizedString(
-            key: alert["title-loc-key"] as? String,
-            args: alert["title-loc-args"] as? [Any],
-            fallback: original.title
-        )
-
-        content.subtitle = resolveLocalizedString(
-            key: alert["subtitle-loc-key"] as? String,
-            args: alert["subtitle-loc-args"] as? [Any],
-            fallback: original.subtitle
-        )
-
-        content.body = resolveLocalizedString(
-            key: alert["loc-key"] as? String,
-            args: alert["loc-args"] as? [Any],
-            fallback: original.body
-        )
-
-        content.sound = original.sound
-        content.badge = original.badge
-        content.userInfo = original.userInfo
-        content.categoryIdentifier = original.categoryIdentifier
-        content.threadIdentifier = original.threadIdentifier
-
-        if let interruptionLevel = aps["interruption-level"] as? String {
-            switch interruptionLevel {
-            case "passive": content.interruptionLevel = .passive
-            case "active": content.interruptionLevel = .active
-            case "time-sensitive": content.interruptionLevel = .timeSensitive
-            case "critical": content.interruptionLevel = .critical
-            default: content.interruptionLevel = original.interruptionLevel
-            }
-        } else {
-            content.interruptionLevel = original.interruptionLevel
-        }
-
-        return content
-    }
-
-    static func resolveLocalizedString(key: String?, args: [Any]?, fallback: String) -> String {
-        guard let key = key else { return fallback }
-
-        let format = NSLocalizedString(key, comment: "")
-
-        guard format != key else { return fallback }
-
-        guard let args = args, !args.isEmpty else { return format }
-
-        return String(format: format, arguments: args.map { "\($0)" as NSString })
     }
 }

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -124,6 +124,15 @@ extension UNMutableNotificationContent {
 
         guard let args = args, !args.isEmpty else { return format }
 
-        return String(format: format, arguments: args.map { "\($0)" as NSString })
+        let stringArgs = args.map { String(describing: $0) }
+
+        switch stringArgs.count {
+        case 1: return String(format: format, stringArgs[0])
+        case 2: return String(format: format, stringArgs[0], stringArgs[1])
+        case 3: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2])
+        case 4: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3])
+        case 5: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3], stringArgs[4])
+        default: return format
+        }
     }
 }

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -124,15 +124,6 @@ extension UNMutableNotificationContent {
 
         guard let args = args, !args.isEmpty else { return format }
 
-        let stringArgs = args.map { String(describing: $0) }
-
-        switch stringArgs.count {
-        case 1: return String(format: format, stringArgs[0])
-        case 2: return String(format: format, stringArgs[0], stringArgs[1])
-        case 3: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2])
-        case 4: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3])
-        case 5: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3], stringArgs[4])
-        default: return format
-        }
+        return String(format: format, arguments: args.map { "\($0)" as NSString })
     }
 }

--- a/Ruddarr.xcodeproj/project.pbxproj
+++ b/Ruddarr.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		BB50F2272C3B06AD005E14CA /* QueueListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB50F2262C3B06AD005E14CA /* QueueListItem.swift */; };
 		BB50F2292C3B3322005E14CA /* ActivityView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB50F2282C3B3322005E14CA /* ActivityView+Toolbar.swift */; };
 		BB5379D02C3DD38500B65E95 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB5379CF2C3DD38500B65E95 /* Localizable.xcstrings */; };
+		BB5379D12C3DD38500B65E95 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB5379CF2C3DD38500B65E95 /* Localizable.xcstrings */; };
 		BB54D0232E90932400F5CF42 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB54D01A2E90932400F5CF42 /* AppIcon.icon */; };
 		BB54D0242E90932400F5CF42 /* AppIconBarbie.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB54D01B2E90932400F5CF42 /* AppIconBarbie.icon */; };
 		BB54D0252E90932400F5CF42 /* AppIconBooks.icon in Resources */ = {isa = PBXBuildFile; fileRef = BB54D01C2E90932400F5CF42 /* AppIconBooks.icon */; };
@@ -1136,6 +1137,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BB5379D12C3DD38500B65E95 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/RuddarrTests.swift
+++ b/Tests/RuddarrTests.swift
@@ -1,59 +1,24 @@
 import Testing
 import Foundation
 
-// Replicates the resolveLocalizedString logic from NotificationService
-private func formatLocalized(_ format: String, args: [Any]) -> String {
-    let stringArgs = args.map { String(describing: $0) }
-
-    switch stringArgs.count {
-    case 1: return String(format: format, stringArgs[0])
-    case 2: return String(format: format, stringArgs[0], stringArgs[1])
-    case 3: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2])
-    case 4: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3])
-    case 5: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3], stringArgs[4])
-    default: return format
-    }
-}
-
 struct RuddarrTests {
     @Test func resolveLocalizedStringWithArgs() {
         let format = "%@ (S%@ E%@)"
         let args: [Any] = ["Breaking Bad", "1", "23"]
-        let result = formatLocalized(format, args: args)
+        let result = String(format: format, arguments: args.map { "\($0)" as NSString })
         #expect(result == "Breaking Bad (S1 E23)")
     }
 
     @Test func resolveLocalizedStringWithIntArgs() {
         let format = "%@ (S%@ E%@)"
         let args: [Any] = ["Breaking Bad", 2, 45]
-        let result = formatLocalized(format, args: args)
+        let result = String(format: format, arguments: args.map { "\($0)" as NSString })
         #expect(result == "Breaking Bad (S2 E45)")
-    }
-
-    @Test func resolveLocalizedStringWithMixedArgs() {
-        let format = "%@ (%@)"
-        let args: [Any] = ["The Super Mario Bros. Movie", 2023]
-        let result = formatLocalized(format, args: args)
-        #expect(result == "The Super Mario Bros. Movie (2023)")
-    }
-
-    @Test func resolveLocalizedStringWithPositionalArgs() {
-        let format = "%2$@ Episodes Downloaded on %1$@"
-        let args: [Any] = ["Sonarr", 5]
-        let result = formatLocalized(format, args: args)
-        #expect(result == "5 Episodes Downloaded on Sonarr")
-    }
-
-    @Test func resolveLocalizedStringWithPositionalIntArgs() {
-        let format = "Upgraded from %1$@ to %2$@"
-        let args: [Any] = ["HDTV-720p", "Bluray-1080p"]
-        let result = formatLocalized(format, args: args)
-        #expect(result == "Upgraded from HDTV-720p to Bluray-1080p")
     }
 
     @Test func resolveLocalizedStringWithNoArgs() {
         let format = "Episode Downloaded"
-        let result = formatLocalized(format, args: [])
+        let result = String(format: format, arguments: [])
         #expect(result == "Episode Downloaded")
     }
 

--- a/Tests/RuddarrTests.swift
+++ b/Tests/RuddarrTests.swift
@@ -1,24 +1,59 @@
 import Testing
 import Foundation
 
+// Replicates the resolveLocalizedString logic from NotificationService
+private func formatLocalized(_ format: String, args: [Any]) -> String {
+    let stringArgs = args.map { String(describing: $0) }
+
+    switch stringArgs.count {
+    case 1: return String(format: format, stringArgs[0])
+    case 2: return String(format: format, stringArgs[0], stringArgs[1])
+    case 3: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2])
+    case 4: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3])
+    case 5: return String(format: format, stringArgs[0], stringArgs[1], stringArgs[2], stringArgs[3], stringArgs[4])
+    default: return format
+    }
+}
+
 struct RuddarrTests {
     @Test func resolveLocalizedStringWithArgs() {
         let format = "%@ (S%@ E%@)"
         let args: [Any] = ["Breaking Bad", "1", "23"]
-        let result = String(format: format, arguments: args.map { "\($0)" as NSString })
+        let result = formatLocalized(format, args: args)
         #expect(result == "Breaking Bad (S1 E23)")
     }
 
     @Test func resolveLocalizedStringWithIntArgs() {
         let format = "%@ (S%@ E%@)"
         let args: [Any] = ["Breaking Bad", 2, 45]
-        let result = String(format: format, arguments: args.map { "\($0)" as NSString })
+        let result = formatLocalized(format, args: args)
         #expect(result == "Breaking Bad (S2 E45)")
+    }
+
+    @Test func resolveLocalizedStringWithMixedArgs() {
+        let format = "%@ (%@)"
+        let args: [Any] = ["The Super Mario Bros. Movie", 2023]
+        let result = formatLocalized(format, args: args)
+        #expect(result == "The Super Mario Bros. Movie (2023)")
+    }
+
+    @Test func resolveLocalizedStringWithPositionalArgs() {
+        let format = "%2$@ Episodes Downloaded on %1$@"
+        let args: [Any] = ["Sonarr", 5]
+        let result = formatLocalized(format, args: args)
+        #expect(result == "5 Episodes Downloaded on Sonarr")
+    }
+
+    @Test func resolveLocalizedStringWithPositionalIntArgs() {
+        let format = "Upgraded from %1$@ to %2$@"
+        let args: [Any] = ["HDTV-720p", "Bluray-1080p"]
+        let result = formatLocalized(format, args: args)
+        #expect(result == "Upgraded from HDTV-720p to Bluray-1080p")
     }
 
     @Test func resolveLocalizedStringWithNoArgs() {
         let format = "Episode Downloaded"
-        let result = String(format: format, arguments: [])
+        let result = formatLocalized(format, args: [])
         #expect(result == "Episode Downloaded")
     }
 


### PR DESCRIPTION
Use variadic String(format:) instead of String(format:arguments:) to
avoid CVarArg/va_list bridging issues on macOS when notification
payloads contain integer values in loc-args instead of strings.

https://claude.ai/code/session_01MtLgws8sXVpp1ptwQu1pv5