### PR TITLE
detect multilingual releases by title keywords in list display

### DIFF
--- a/Ruddarr/Models/Movies/MovieReleases.swift
+++ b/Ruddarr/Models/Movies/MovieReleases.swift
@@ -212,7 +212,11 @@ struct MovieRelease: Identifiable, Codable {
     }
 
     var languageLabel: String {
-        languageSingleLabel(languages)
+        if languages.count <= 1 && title.lowercased().contains(/\b(multi|dual)\b/) {
+            return String(localized: "Multilingual")
+        }
+
+        return languageSingleLabel(languages)
     }
 
     var languagesLabel: String {

--- a/Ruddarr/Models/Series/SeriesReleases.swift
+++ b/Ruddarr/Models/Series/SeriesReleases.swift
@@ -236,7 +236,11 @@ struct SeriesRelease: Identifiable, Codable {
     }
 
     var languageLabel: String {
-        languageSingleLabel(languages ?? [])
+        if (languages ?? []).count <= 1 && title.lowercased().contains(/\b(multi|dual)\b/) {
+            return String(localized: "Multilingual")
+        }
+
+        return languageSingleLabel(languages ?? [])
     }
 
     var languagesLabel: String {

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,6 +1,1 @@
-
-# macOS
-- Fixed notifications containing decimals
-
-# Releases
 - Releases with "DUAL" or "MULTI" in the title now display as Multilingual in the list

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,3 +1,6 @@
 
 # macOS
 - Fixed notifications containing decimals
+
+# Releases
+- Releases with "DUAL" or "MULTI" in the title now display as Multilingual in the list


### PR DESCRIPTION
Releases with "dual" or "multi" in the title (word boundary matched)
now show as Multilingual in the list, matching existing filter behavior.

https://claude.ai/code/session_01RSP7LSeisFhN1BcuNxNNyG