### PR TITLE
Check for empty instances

### DIFF
--- a/Ruddarr/Views/Series/Search/SeriesSearchView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesSearchView.swift
@@ -14,7 +14,7 @@ struct SeriesSearchView: View {
         @Bindable var seriesLookup = instance.lookup
 
         ScrollView {
-            if seriesLookup.sortedItems.isEmpty && searchQuery.isEmpty {
+            if seriesLookup.sortedItems.isEmpty, searchQuery.isEmpty, !instance.series.items.isEmpty {
                 MediaGrid(items: discovery.series) { item in
                     DiscoveryGridPoster(item: item)
                 } header: {

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,3 +1,4 @@
+- Avoid showing discovery grid for fresh Sonarr instances
 
 # macOS
 - Fixed notifications containing decimals


### PR DESCRIPTION
Hide discovery grid if Sonarr instance is empty.

Fixes #641.