### PR TITLE
Debounce movie and series search with SwiftUI tasks

### DIFF
--- a/Ruddarr/Utilities/Helpers.swift
+++ b/Ruddarr/Utilities/Helpers.swift
@@ -1,6 +1,25 @@
 import Foundation
 import CloudKit
 
+struct SearchRequest: Equatable {
+    private let id = UUID()
+
+    let query: String
+    let isDebounced: Bool
+
+    init(query: String, isDebounced: Bool) {
+        self.query = query
+        self.isDebounced = isDebounced
+    }
+
+    func waitForDebounce() async -> Bool {
+        guard isDebounced else { return true }
+
+        try? await Task.sleep(for: .milliseconds(250))
+        return !Task.isCancelled
+    }
+}
+
 protocol OptionalProtocol {
     associatedtype Wrapped
     var wrappedValue: Wrapped? { get set }

--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
-import Combine
 
 struct MovieSearchView: View {
     @State var searchQuery: String
     @State private var searchPresented: Bool = true
+    @State private var searchRequest: SearchRequest?
 
     @Environment(RadarrInstance.self) private var instance
-
-    let searchTextPublisher = PassthroughSubject<String, Never>()
 
     var body: some View {
         @Bindable var discovery = Discovery.shared
@@ -56,13 +54,13 @@ struct MovieSearchView: View {
             await discovery.fetch(.movies)
         }
         .onSubmit(of: .search) {
-            searchTextPublisher.send(searchQuery)
+            performSearch()
         }
         .onChange(of: searchQuery, initial: true, handleSearchQueryChange)
-        .onReceive(
-            searchTextPublisher.debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
-        ) { _ in
-            performSearch()
+        .task(id: searchRequest) {
+            guard let searchRequest, await searchRequest.waitForDebounce() else { return }
+
+            await instance.lookup.search(query: searchRequest.query)
         }
         .alert(
             isPresented: instance.lookup.errorBinding,
@@ -81,10 +79,8 @@ struct MovieSearchView: View {
         }
     }
 
-    func performSearch() {
-        Task {
-            await instance.lookup.search(query: searchQuery)
-        }
+    func performSearch(debounced: Bool = false) {
+        searchRequest = SearchRequest(query: searchQuery, isDebounced: debounced)
     }
 
     func handleSearchQueryChange(oldQuery: String, newQuery: String) {
@@ -99,7 +95,7 @@ struct MovieSearchView: View {
         } else if oldQuery == newQuery {
             performSearch() // always perform initial search
         } else {
-            searchTextPublisher.send(searchQuery)
+            performSearch(debounced: true)
         }
     }
 }

--- a/Ruddarr/Views/Series/Search/SeriesSearchView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesSearchView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
-import Combine
 
 struct SeriesSearchView: View {
     @State var searchQuery: String
     @State private var searchPresented: Bool = true
+    @State private var searchRequest: SearchRequest?
 
     @Environment(SonarrInstance.self) private var instance
-
-    let searchTextPublisher = PassthroughSubject<String, Never>()
 
     var body: some View {
         @Bindable var discovery = Discovery.shared
@@ -54,13 +52,13 @@ struct SeriesSearchView: View {
             await discovery.fetch(.series)
         }
         .onSubmit(of: .search) {
-            searchTextPublisher.send(searchQuery)
+            performSearch()
         }
         .onChange(of: searchQuery, initial: true, handleSearchQueryChange)
-        .onReceive(
-            searchTextPublisher.debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
-        ) { _ in
-            performSearch()
+        .task(id: searchRequest) {
+            guard let searchRequest, await searchRequest.waitForDebounce() else { return }
+
+            await instance.lookup.search(query: searchRequest.query)
         }
         .alert(
             isPresented: instance.lookup.errorBinding,
@@ -79,10 +77,8 @@ struct SeriesSearchView: View {
         }
     }
 
-    func performSearch() {
-        Task { @MainActor in
-            await instance.lookup.search(query: searchQuery)
-        }
+    func performSearch(debounced: Bool = false) {
+        searchRequest = SearchRequest(query: searchQuery, isDebounced: debounced)
     }
 
     func handleSearchQueryChange(oldQuery: String, newQuery: String) {
@@ -97,7 +93,7 @@ struct SeriesSearchView: View {
         } else if oldQuery == newQuery {
             performSearch() // always perform initial search
         } else {
-            searchTextPublisher.send(searchQuery)
+            performSearch(debounced: true)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the local Combine search publishers in movie and series search with SwiftUI task(id:) driven search requests
- Add a small SearchRequest value to keep repeated query/debounce state readable
- Keep typed search input debounced while allowing submit and initial non-empty queries to run immediately
- Leave unrelated alert fallback and discovery-grid logic unchanged

## Verification
- Ran git diff --check
- Did not run an Xcode build