### PR TITLE
Fix Norwegian language code

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -17,6 +17,7 @@ brew install crowdin yq
 EXPORTED=(en $(yq '.export_languages[]' crowdin.yml))
 
 # Convert Crowdin codes to Apple language codes
+EXPORTED=("${EXPORTED[@]/no/nb}")
 EXPORTED=("${EXPORTED[@]/es-ES/es}")
 EXPORTED=("${EXPORTED[@]/zh-CN/zh-Hans}")
 


### PR DESCRIPTION
Replace 'no' with 'nb' in exported language codes.