### PR TITLE
Add rich activity layout

### DIFF
--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -132,6 +132,30 @@ struct QueueItem: Codable, Identifiable, Equatable {
         (downloadId ?? "") + (title ?? "") + String(seasonNumber ?? id) + String(size)
     }
 
+    var remotePoster: String? {
+        if let poster = movie?.remotePoster {
+            return poster
+        }
+
+        if let poster = series?.remotePoster {
+            return poster
+        }
+
+        return episode?.series?.remotePoster
+    }
+
+    var posterPlaceholder: String? {
+        if let title = movie?.title {
+            return title
+        }
+
+        if let title = series?.title {
+            return title
+        }
+
+        return episode?.series?.title
+    }
+
     var titleLabel: String {
         if let title = movie?.title {
             return title
@@ -154,7 +178,12 @@ struct QueueItem: Codable, Identifiable, Equatable {
 
     var progressLabel: String {
         guard sizeleft > 0 else { return 100.formatted(.percent) }
-        return ((size - sizeleft) / size).formatted(.percent.precision(.fractionLength(1)))
+        return progressFraction.formatted(.percent.precision(.fractionLength(1)))
+    }
+
+    var progressFraction: Float {
+        guard size > 0 else { return sizeleft <= 0 ? 1 : 0 }
+        return min(max((size - sizeleft) / size, 0), 1)
     }
 
     var remainingLabel: String? {

--- a/Ruddarr/Services/AppSettings.swift
+++ b/Ruddarr/Services/AppSettings.swift
@@ -16,6 +16,7 @@ class AppSettings: ObservableObject {
     @AppStorage("theme", store: dependencies.store) var theme: Theme = .factory
     @AppStorage("appearance", store: dependencies.store) var appearance: Appearance = .automatic
     @AppStorage("grid", store: dependencies.store) var grid: GridStyle = .posters
+    @AppStorage("richActivityDisplay", store: dependencies.store) var richActivityDisplay: Bool = true
 
     @AppStorage("tab", store: dependencies.store) var tab: TabItem = .movies
     @AppStorage("releaseFilters", store: dependencies.store) var releaseFilters: ReleaseFilters = .reset
@@ -105,6 +106,7 @@ extension AppSettings {
             "theme": theme.rawValue,
             "tab": tab.rawValue,
             "appearance": appearance.rawValue,
+            "richActivityDisplay": richActivityDisplay,
         ]
 
         for instance in configuredInstances {

--- a/Ruddarr/Views/Activity/QueueListItem.swift
+++ b/Ruddarr/Views/Activity/QueueListItem.swift
@@ -4,9 +4,57 @@ struct QueueListItem: View {
     var item: QueueItem
 
     @State private var time = Date()
+    @EnvironmentObject var settings: AppSettings
+
     private let timer = Timer.publish(every: 1, tolerance: 0.5, on: .main, in: .common).autoconnect()
 
     var body: some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .onReceive(timer) { _ in
+                if item.trackedDownloadState == .downloading {
+                    withAnimation {
+                        time = Date()
+                    }
+                }
+            }
+    }
+
+    @ViewBuilder
+    var content: some View {
+        if settings.richActivityDisplay {
+            richContent
+                .padding(8)
+                .background(Color.card, in: RoundedRectangle(cornerRadius: 14))
+        } else {
+            compactContent
+        }
+    }
+
+    var richContent: some View {
+        HStack(alignment: .center, spacing: 10) {
+            QueuePoster(url: item.remotePoster, title: item.posterPlaceholder)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.titleLabel)
+                    .font(.headline.monospacedDigit())
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if item.trackedDownloadState == .downloading {
+                    downloadProgress
+                } else {
+                    status
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    var compactContent: some View {
         VStack(alignment: .leading) {
             Text(item.titleLabel)
                 .font(.headline.monospacedDigit())
@@ -41,15 +89,67 @@ struct QueueListItem: View {
             .foregroundStyle(.secondary)
             .lineLimit(1)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .onReceive(timer) { _ in
-            if item.trackedDownloadState == .downloading {
-                withAnimation {
-                    time = Date()
-                }
+    }
+
+    var status: some View {
+        HStack(spacing: 6) {
+            Text(item.statusLabel)
+
+            if item.hasIssue {
+                Spacer()
+                Image(systemName: "exclamationmark.triangle")
+                    .imageScale(.small)
+                    .foregroundStyle(.tint)
             }
         }
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+
+    var downloadProgress: some View {
+        ProgressView(value: progressValue, total: progressTotal) {
+            HStack(spacing: 6) {
+                Text(item.progressLabel)
+                    .monospacedDigit()
+
+                Spacer()
+
+                Text(item.remainingLabel ?? "")
+                    .monospacedDigit()
+                    .id(time)
+
+                if item.hasIssue {
+                    Image(systemName: "exclamationmark.triangle")
+                        .imageScale(.small)
+                        .foregroundStyle(.tint)
+                }
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+    }
+
+    var progressValue: Float {
+        max(0, item.size - item.sizeleft)
+    }
+
+    var progressTotal: Float {
+        max(item.size, 1)
+    }
+}
+
+private struct QueuePoster: View {
+    var url: String?
+    var title: String?
+
+    var body: some View {
+        CachedAsyncImage(.poster, url, placeholder: title)
+            .aspectRatio(CGSize(width: 150, height: 225), contentMode: .fill)
+            .frame(width: 44, height: 66)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .contentShape(RoundedRectangle(cornerRadius: 8))
     }
 }
 

--- a/Ruddarr/Views/ActivityView.swift
+++ b/Ruddarr/Views/ActivityView.swift
@@ -26,11 +26,15 @@ struct ActivityView: View {
                                     QueueListItem(item: item)
                                 }
                                 .buttonStyle(.plain)
+                                #if os(iOS)
+                                    .listRowInsets(settings.richActivityDisplay ? richActivityRowInsets : nil)
+                                    .listRowSeparator(settings.richActivityDisplay ? .hidden : .automatic)
+                                #endif
                             }
                             #if os(macOS)
                                 .padding(.vertical, 4)
                             #else
-                                .listRowBackground(Color.card)
+                                .listRowBackground(settings.richActivityDisplay ? Color.clear : Color.card)
                             #endif
                         } header: {
                             if !items.isEmpty { sectionHeader }
@@ -103,6 +107,10 @@ struct ActivityView: View {
                     .tint(.secondary)
             }
         }
+    }
+
+    var richActivityRowInsets: EdgeInsets {
+        EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0)
     }
 
     func updateSelectedItem() {

--- a/Ruddarr/Views/Settings/SettingsDisplaySection.swift
+++ b/Ruddarr/Views/Settings/SettingsDisplaySection.swift
@@ -13,6 +13,8 @@ struct SettingsDisplaySection: View {
             #if os(iOS)
                 iconPicker
             #endif
+
+            richActivityDisplayToggle
         } header: {
             Text("Display", comment: "Preferences section title")
         }
@@ -33,6 +35,13 @@ struct SettingsDisplaySection: View {
             Label("Appearance", systemImage: icon)
                 .labelStyle(SettingsIconLabelStyle())
         }.tint(.secondary)
+    }
+
+    var richActivityDisplayToggle: some View {
+        Toggle(isOn: $settings.richActivityDisplay) {
+            Label("Rich Display on Activity", systemImage: TabItem.activity.icon)
+                .labelStyle(SettingsIconLabelStyle())
+        }
     }
 
     var themePicker: some View {


### PR DESCRIPTION
## Summary
- Add poster artwork and download progress details to Activity queue rows
- Add a Settings toggle for Rich Display on Activity
- Preserve the original compact Activity row layout when the toggle is disabled

## Testing
- on simulator and on iPhone 17