### PR TITLE
Sort activity tasks by progress

### DIFF
--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -153,8 +153,17 @@ struct QueueItem: Codable, Identifiable, Equatable {
     }
 
     var progressLabel: String {
-        guard sizeleft > 0 else { return 100.formatted(.percent) }
-        return ((size - sizeleft) / size).formatted(.percent.precision(.fractionLength(1)))
+        progressFraction.formatted(.percent.precision(.fractionLength(1)))
+    }
+
+    var progressFraction: Float {
+        guard size > 0 else { return sizeleft <= 0 ? 1 : 0 }
+        return min(max((size - sizeleft) / size, 0), 1)
+    }
+
+    var isActivelyDownloading: Bool {
+        status == "downloading" ||
+        trackedDownloadState == .downloading
     }
 
     var remainingLabel: String? {

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -153,17 +153,13 @@ struct QueueItem: Codable, Identifiable, Equatable {
     }
 
     var progressLabel: String {
-        progressFraction.formatted(.percent.precision(.fractionLength(1)))
+        guard progressFraction < 1 else { return 100.formatted(.percent) }
+        return progressFraction.formatted(.percent.precision(.fractionLength(1)))
     }
 
     var progressFraction: Float {
         guard size > 0 else { return sizeleft <= 0 ? 1 : 0 }
         return min(max((size - sizeleft) / size, 0), 1)
-    }
-
-    var isActivelyDownloading: Bool {
-        status == "downloading" ||
-        trackedDownloadState == .downloading
     }
 
     var remainingLabel: String? {

--- a/Ruddarr/Views/Activity/ActivityView+Toolbar.swift
+++ b/Ruddarr/Views/Activity/ActivityView+Toolbar.swift
@@ -21,7 +21,7 @@ extension ActivityView {
 
     func updateSortDirection() {
         switch sort.option {
-        case .byAdded:
+        case .byAdded, .byProgress:
             sort.isAscending = false
         default:
             sort.isAscending = true

--- a/Ruddarr/Views/Activity/QueueSort.swift
+++ b/Ruddarr/Views/Activity/QueueSort.swift
@@ -15,11 +15,13 @@ struct QueueSort: Equatable {
 
         case byTitle
         case byAdded
+        case byProgress
 
         var label: some View {
             switch self {
             case .byTitle: Label("Title", systemImage: "textformat.abc")
             case .byAdded: Label("Added", systemImage: "calendar.badge.plus")
+            case .byProgress: Label("Progress", systemImage: "gauge")
             }
         }
 
@@ -29,8 +31,31 @@ struct QueueSort: Equatable {
                 lhs.titleLabel < rhs.titleLabel
             case .byAdded:
                 lhs.added ?? Date.distantPast < rhs.added ?? Date.distantPast
+            case .byProgress:
+                lhs.progressFraction < rhs.progressFraction
             }
         }
+    }
+
+    func isOrderedBefore(_ lhs: QueueItem, _ rhs: QueueItem) -> Bool {
+        switch option {
+        case .byProgress:
+            isProgressOrderedBefore(lhs, rhs)
+        default:
+            isAscending ? option.isOrderedBefore(lhs, rhs) : option.isOrderedBefore(rhs, lhs)
+        }
+    }
+
+    private func isProgressOrderedBefore(_ lhs: QueueItem, _ rhs: QueueItem) -> Bool {
+        if lhs.isActivelyDownloading != rhs.isActivelyDownloading {
+            return lhs.isActivelyDownloading
+        }
+
+        if lhs.progressFraction != rhs.progressFraction {
+            return isAscending ? lhs.progressFraction < rhs.progressFraction : lhs.progressFraction > rhs.progressFraction
+        }
+
+        return lhs.titleLabel < rhs.titleLabel
     }
 
     var hasFilter: Bool {

--- a/Ruddarr/Views/Activity/QueueSort.swift
+++ b/Ruddarr/Views/Activity/QueueSort.swift
@@ -32,30 +32,15 @@ struct QueueSort: Equatable {
             case .byAdded:
                 lhs.added ?? Date.distantPast < rhs.added ?? Date.distantPast
             case .byProgress:
-                lhs.progressFraction < rhs.progressFraction
+                lhs.progressFraction != rhs.progressFraction
+                    ? lhs.progressFraction < rhs.progressFraction
+                    : lhs.titleLabel < rhs.titleLabel
             }
         }
     }
 
     func isOrderedBefore(_ lhs: QueueItem, _ rhs: QueueItem) -> Bool {
-        switch option {
-        case .byProgress:
-            isProgressOrderedBefore(lhs, rhs)
-        default:
-            isAscending ? option.isOrderedBefore(lhs, rhs) : option.isOrderedBefore(rhs, lhs)
-        }
-    }
-
-    private func isProgressOrderedBefore(_ lhs: QueueItem, _ rhs: QueueItem) -> Bool {
-        if lhs.isActivelyDownloading != rhs.isActivelyDownloading {
-            return lhs.isActivelyDownloading
-        }
-
-        if lhs.progressFraction != rhs.progressFraction {
-            return isAscending ? lhs.progressFraction < rhs.progressFraction : lhs.progressFraction > rhs.progressFraction
-        }
-
-        return lhs.titleLabel < rhs.titleLabel
+        isAscending ? option.isOrderedBefore(lhs, rhs) : option.isOrderedBefore(rhs, lhs)
     }
 
     var hasFilter: Bool {

--- a/Ruddarr/Views/ActivityView.swift
+++ b/Ruddarr/Views/ActivityView.swift
@@ -129,7 +129,7 @@ struct ActivityView: View {
 
         var items: [QueueItem] = grouped
             .flatMap { $0.value }
-            .sorted(by: sort.option.isOrderedBefore)
+            .sorted(by: sort.isOrderedBefore)
 
         if sort.instance != .all {
             items = items.filter {
@@ -147,10 +147,6 @@ struct ActivityView: View {
 
         if sort.issues {
             items = items.filter { $0.trackedDownloadStatus != .ok || $0.status == "warning" }
-        }
-
-        if !sort.isAscending {
-            items = items.reversed()
         }
 
         withAnimation {

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,1 +1,1 @@
-- 
+- Support sort queue tasks by progress


### PR DESCRIPTION
## Summary
- Adds Progress as an Activity sort option using the gauge icon.
- Sorts queue items by download progress while keeping actively downloading tasks ahead of import-pending and other non-downloading states.
- Uses a shared progress fraction helper for task display and sorting.

## Testing
- Built successfully with `xcodebuild -project Ruddarr.xcodeproj -scheme Ruddarr -configuration Debug -destination id=0FEADBED-766F-4EEB-A07B-FC28167F9428 -derivedDataPath ./DerivedData-ProgressSortPR -skipPackagePluginValidation build`.
- Tested in the iOS simulator with mock queue data; demo mode is not included in this branch.