### PR TITLE
Clarify search placeholders

### DIFF
--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -41,7 +41,8 @@ struct MovieSearchView: View {
         .searchable(
             text: $searchQuery,
             isPresented: $searchPresented,
-            placement: .drawerOrToolbar(.always)
+            placement: .drawerOrToolbar(.always),
+            prompt: "Search for a movie to add"
         )
         .disabled(instance.isVoid)
         .autocorrectionDisabled(true)

--- a/Ruddarr/Views/MoviesView.swift
+++ b/Ruddarr/Views/MoviesView.swift
@@ -86,7 +86,8 @@ struct MoviesView: View {
             .searchable(
                 text: $searchQuery,
                 isPresented: $searchPresented,
-                placement: .drawerOrToolbar
+                placement: .drawerOrToolbar,
+                prompt: "Search your Movie library"
             )
             .autocorrectionDisabled(true)
             .onChange(of: settings.radarrInstanceId, changeInstance)

--- a/Ruddarr/Views/Series/Search/SeriesSearchView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesSearchView.swift
@@ -39,7 +39,8 @@ struct SeriesSearchView: View {
         .searchable(
             text: $searchQuery,
             isPresented: $searchPresented,
-            placement: .drawerOrToolbar(.always)
+            placement: .drawerOrToolbar(.always),
+            prompt: "Search for a series to add"
         )
         .disabled(instance.isVoid)
         .autocorrectionDisabled(true)

--- a/Ruddarr/Views/SeriesView.swift
+++ b/Ruddarr/Views/SeriesView.swift
@@ -87,7 +87,8 @@ struct SeriesView: View {
             .searchable(
                 text: $searchQuery,
                 isPresented: $searchPresented,
-                placement: .drawerOrToolbar
+                placement: .drawerOrToolbar,
+                prompt: "Search your Series library"
             )
             .autocorrectionDisabled(true)
             .onChange(of: settings.sonarrInstanceId, changeInstance)


### PR DESCRIPTION
## Summary
- Updates the Movies library search placeholder to clarify it searches the existing movie library.
- Updates the Series library search placeholder to clarify it searches the existing series library.
- Adds clearer prompts for adding movies and series from their search screens.

## Testing
- Built successfully with `xcodebuild -project Ruddarr.xcodeproj -scheme Ruddarr -configuration Debug -destination id=0FEADBED-766F-4EEB-A07B-FC28167F9428 -derivedDataPath ./DerivedData-SearchPlaceholdersPR -skipPackagePluginValidation build`.
- Installed and tested in the iOS simulator.
- Captured screenshots for Movies library search, Series library search, Add Movie search, and Add Series search.