### PR TITLE
Show calendar download progress

### DIFF
--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -154,7 +154,17 @@ struct QueueItem: Codable, Identifiable, Equatable {
 
     var progressLabel: String {
         guard sizeleft > 0 else { return 100.formatted(.percent) }
-        return ((size - sizeleft) / size).formatted(.percent.precision(.fractionLength(1)))
+        return progressFraction.formatted(.percent.precision(.fractionLength(1)))
+    }
+
+    var progressFraction: Float {
+        guard size > 0 else { return sizeleft <= 0 ? 1 : 0 }
+        return min(max((size - sizeleft) / size, 0), 1)
+    }
+
+    var hasDownloadProgress: Bool {
+        trackedDownloadState == .downloading ||
+        status == "downloading"
     }
 
     var remainingLabel: String? {

--- a/Ruddarr/Views/Calendar/CalendarMedia.swift
+++ b/Ruddarr/Views/Calendar/CalendarMedia.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CalendarMovie: View {
     var date: Date
     var movie: Movie
+    var downloadProgress: Float?
 
     @EnvironmentObject var settings: AppSettings
 
@@ -17,10 +18,7 @@ struct CalendarMovie: View {
 
                     Spacer()
 
-                    statusIcon
-                        .font(.subheadline)
-                        .imageScale(.small)
-                        .foregroundStyle(.secondary)
+                    status
                 }
 
                 if let type = movie.releaseType(for: date) {
@@ -52,6 +50,18 @@ struct CalendarMovie: View {
     }
 
     @ViewBuilder
+    var status: some View {
+        if let downloadProgress {
+            CalendarDownloadProgress(progress: downloadProgress)
+        } else {
+            statusIcon
+                .font(.subheadline)
+                .imageScale(.small)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
     var statusIcon: some View {
         if movie.isDownloaded {
             Image(systemName: "checkmark").symbolVariant(.circle.fill)
@@ -67,6 +77,7 @@ struct CalendarMovie: View {
 
 struct CalendarEpisode: View {
     var episode: Episode
+    var downloadProgress: Float?
 
     @EnvironmentObject var settings: AppSettings
 
@@ -97,9 +108,7 @@ struct CalendarEpisode: View {
 
                 Spacer()
 
-                statusIcon
-                    .foregroundStyle(.secondary)
-                    .imageScale(.small)
+                status
             }
             .foregroundStyle(.secondary)
             .font(.subheadline)
@@ -155,6 +164,17 @@ struct CalendarEpisode: View {
     }
 
     @ViewBuilder
+    var status: some View {
+        if let downloadProgress {
+            CalendarDownloadProgress(progress: downloadProgress)
+        } else {
+            statusIcon
+                .foregroundStyle(.secondary)
+                .imageScale(.small)
+        }
+    }
+
+    @ViewBuilder
     var statusIcon: some View {
         if episode.isDownloaded {
             Image(systemName: "checkmark").symbolVariant(.circle.fill)
@@ -169,6 +189,27 @@ struct CalendarEpisode: View {
 
     var isGrouped: Bool {
         (episode.calendarGroupCount ?? 0) > 2
+    }
+}
+
+private struct CalendarDownloadProgress: View {
+    var progress: Float
+
+    @EnvironmentObject var settings: AppSettings
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.secondary.opacity(0.28), lineWidth: 2)
+
+            Circle()
+                .trim(from: 0, to: CGFloat(progress))
+                .stroke(settings.theme.tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 18, height: 18)
+        .accessibilityLabel("Downloading")
+        .accessibilityValue(progress.formatted(.percent.precision(.fractionLength(0))))
     }
 }
 

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CalendarView: View {
     @State var calendar = MediaCalendar()
+    @State var queue = Queue.shared
 
     @State private var scrollView: ScrollViewProxy?
     @State private var initializationError: API.Error?
@@ -80,6 +81,8 @@ struct CalendarView: View {
                 todayButton
             }
             .onAppear {
+                queue.instances = settings.instances
+
                 if Set(calendar.instances.map(\.id)) != Set(settings.instances.map(\.id)) {
                     calendar.reset()
                     calendar.instances = settings.instances
@@ -93,6 +96,10 @@ struct CalendarView: View {
             }
             .task {
                 await load()
+            }
+            .task {
+                queue.instances = settings.instances
+                await queue.fetchTasks()
             }
             .alert(
                 isPresented: $alertPresented,
@@ -241,13 +248,20 @@ struct CalendarView: View {
         VStack(spacing: 8) {
             if displayMovies, let movies = filteredMovies[timestamp] {
                 ForEach(movies) { movie in
-                    CalendarMovie(date: date, movie: movie)
+                    CalendarMovie(
+                        date: date,
+                        movie: movie,
+                        downloadProgress: downloadProgress(for: movie)
+                    )
                 }
             }
 
             if displaySeries, let episodes = filteredEpisodes[timestamp] {
                 ForEach(episodes) { episode in
-                    CalendarEpisode(episode: episode)
+                    CalendarEpisode(
+                        episode: episode,
+                        downloadProgress: downloadProgress(for: episode)
+                    )
                 }
             }
 
@@ -368,6 +382,44 @@ struct CalendarView: View {
 
             Label(label, systemImage: "internaldrive")
         }
+    }
+}
+
+extension CalendarView {
+    var activeQueueItems: [QueueItem] {
+        queue.items
+            .flatMap { $0.value }
+            .filter(\.hasDownloadProgress)
+    }
+
+    func activeDownload(for movie: Movie) -> QueueItem? {
+        activeQueueItems.first {
+            $0.instanceId == movie.instanceId &&
+            $0.movieId == movie.id
+        }
+    }
+
+    func downloadProgress(for movie: Movie) -> Float? {
+        activeDownload(for: movie)?.progressFraction
+    }
+
+    func activeDownload(for episode: Episode) -> QueueItem? {
+        activeQueueItems.first {
+            guard $0.instanceId == episode.instanceId else {
+                return false
+            }
+
+            if let episodeId = $0.episodeId {
+                return episodeId == episode.id
+            }
+
+            return $0.seriesId == episode.seriesId &&
+                $0.seasonNumber == episode.seasonNumber
+        }
+    }
+
+    func downloadProgress(for episode: Episode) -> Float? {
+        activeDownload(for: episode)?.progressFraction
     }
 }
 


### PR DESCRIPTION
## Summary
- Shows a circular download progress indicator on Calendar rows when a matching queue item is actively downloading.
- Keeps the original Calendar layout intact by replacing only the existing right-side status icon while a download is active.
- Reuses queue progress for movie and episode matches, with exact episode matching when available.

## Testing
- Built successfully with `xcodebuild`.
- Verified the classic Calendar layout in the simulator with temporary mock download data.