### PR TITLE
Add fallback instance URLs

### DIFF
--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -75,7 +75,8 @@ extension API {
 
         try await NetworkMonitor.shared.checkReachability()
 
-        var request = URLRequest(url: url)
+        let resolvedURL = InstanceURLResolver.shared.resolvedURL(for: url)
+        var request = URLRequest(url: resolvedURL)
         request.timeoutInterval = timeout
         request.httpMethod = method.rawValue.uppercased()
         request.addValue("application/json", forHTTPHeaderField: "Accept")
@@ -115,12 +116,41 @@ extension API {
         } catch let urlError as URLError where urlError.code == .notConnectedToInternet {
             throw Error.notConnectedToInternet
         } catch let urlError as URLError where urlError.code == .timedOut {
-            guard isPrivateIpAddress(url.host() ?? "") else {
-                throw Error.urlError(urlError)
+            let error: Error = isPrivateIpAddress(resolvedURL.host() ?? "")
+                ? .timeoutOnPrivateIp(urlError)
+                : .urlError(urlError)
+
+            if let fallbackURL = fallbackURL(afterFailureOf: resolvedURL, error: error) {
+                return try await Self.request(
+                    method: method,
+                    url: fallbackURL,
+                    headers: headers,
+                    body: body,
+                    timeout: timeout,
+                    decoder: decoder,
+                    encoder: encoder,
+                    session: session
+                )
             }
-            throw Error.timeoutOnPrivateIp(urlError)
+
+            throw error
         } catch let urlError as URLError {
-            throw Error.urlError(urlError)
+            let error = Error.urlError(urlError)
+
+            if let fallbackURL = fallbackURL(afterFailureOf: resolvedURL, error: error) {
+                return try await Self.request(
+                    method: method,
+                    url: fallbackURL,
+                    headers: headers,
+                    body: body,
+                    timeout: timeout,
+                    decoder: decoder,
+                    encoder: encoder,
+                    session: session
+                )
+            }
+
+            throw error
         } catch let localizedError as any LocalizedError {
             throw Error.localizedError(localizedError)
         } catch let nsError as NSError {
@@ -137,6 +167,7 @@ extension API {
 
         let httpResponse: HTTPURLResponse? = response as? HTTPURLResponse
         let statusCode: Int = httpResponse?.statusCode ?? 599
+        InstanceURLResolver.shared.recordReachable(url, resolvedURL: resolvedURL)
 
         // print(String(data: data, encoding: .utf8) ?? "non-utf8 response")
         // leaveBreadcrumb(.debug, category: "api", message: "Response headers (\(statusCode))", data: parseResponseHeaders(httpResponse))
@@ -206,6 +237,15 @@ extension API {
     private static func parseResponseHeaders(_ response: HTTPURLResponse?) -> [String: Any] {
         guard let headerFields = response?.allHeaderFields else { return [:] }
         return Dictionary(uniqueKeysWithValues: headerFields.compactMap { ($0 as? (String, Any)) })
+    }
+
+    private static func fallbackURL(afterFailureOf url: URL, error: Error) -> URL? {
+        guard let fallbackURL = InstanceURLResolver.shared.fallbackURL(afterFailureOf: url) else {
+            return nil
+        }
+
+        leaveBreadcrumb(.info, category: "api", message: "Retrying with fallback URL", data: ["error": error])
+        return fallbackURL
     }
 }
 

--- a/Ruddarr/Models/Instances/Instance.swift
+++ b/Ruddarr/Models/Instances/Instance.swift
@@ -10,6 +10,7 @@ struct Instance: Identifiable, Equatable, Codable {
     var mode: InstanceMode = .normal
     var label: String = ""
     var url: String = ""
+    var fallbackUrl: String = ""
     var apiKey: String = ""
     var headers: [InstanceHeader] = []
     var rootFolders: [InstanceRootFolder] = []
@@ -32,6 +33,7 @@ struct Instance: Identifiable, Equatable, Codable {
         mode = try values.decode(InstanceMode.self, forKey: .mode)
         label = try values.decode(String.self, forKey: .label)
         url = try values.decode(String.self, forKey: .url)
+        fallbackUrl = try values.decodeIfPresent(String.self, forKey: .fallbackUrl) ?? ""
         apiKey = try values.decode(String.self, forKey: .apiKey)
         headers = try values.decode([InstanceHeader].self, forKey: .headers)
         rootFolders = try values.decode([InstanceRootFolder].self, forKey: .rootFolders)
@@ -58,7 +60,19 @@ struct Instance: Identifiable, Equatable, Codable {
             throw API.Error.invalidUrl(url)
         }
 
+        InstanceURLResolver.shared.register(
+            for: id,
+            preferred: url,
+            fallback: fallbackBaseURL()
+        )
+
         return url
+    }
+
+    func fallbackBaseURL() -> URL? {
+        guard !fallbackUrl.isEmpty else { return nil }
+        guard fallbackUrl.hasPrefix("http://") || fallbackUrl.hasPrefix("https://") else { return nil }
+        return URL(string: fallbackUrl)
     }
 
     func isPrivateIp() -> Bool {
@@ -76,6 +90,127 @@ struct Instance: Identifiable, Equatable, Codable {
         case .releaseSearch: mode.isSlow ? 180 : 90
         case .releaseDownload: 15
         }
+    }
+}
+
+final class InstanceURLResolver: @unchecked Sendable {
+    static let shared = InstanceURLResolver()
+
+    private struct State {
+        var preferred: String
+        var fallback: String?
+        var isUsingFallback = false
+        var lastPreferredFailure: Date?
+    }
+
+    private let lock = NSLock()
+    private let preferredRetryInterval: TimeInterval = 300
+    private var states: [Instance.ID: State] = [:]
+
+    func register(for id: Instance.ID, preferred: URL, fallback: URL?) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let preferred = normalized(preferred)
+        let fallback = fallback.map(normalized)
+        var state = states[id] ?? State(preferred: preferred, fallback: fallback)
+
+        if state.preferred != preferred || state.fallback != fallback {
+            state = State(preferred: preferred, fallback: fallback)
+        }
+
+        states[id] = state
+    }
+
+    func resolvedURL(for url: URL) -> URL {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let absolute = normalized(url)
+
+        for state in states.values {
+            guard let fallback = state.fallback else { continue }
+            guard state.isUsingFallback else { continue }
+            guard let lastPreferredFailure = state.lastPreferredFailure else { continue }
+            guard Date().timeIntervalSince(lastPreferredFailure) < preferredRetryInterval else { continue }
+            guard let retryURL = replacingBase(of: absolute, from: state.preferred, to: fallback) else { continue }
+
+            return retryURL
+        }
+
+        return url
+    }
+
+    func fallbackURL(afterFailureOf failedURL: URL) -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        for (id, state) in states {
+            guard let fallback = state.fallback else { continue }
+            guard let retryURL = replacingBase(of: failedURL, from: state.preferred, to: fallback) else { continue }
+
+            var updated = state
+            updated.isUsingFallback = true
+            updated.lastPreferredFailure = Date()
+            states[id] = updated
+
+            return retryURL
+        }
+
+        return nil
+    }
+
+    func recordReachable(_ url: URL, resolvedURL: URL) {
+        guard normalized(url) == normalized(resolvedURL) else {
+            return
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        for (id, state) in states {
+            guard replacingBase(of: url, from: state.preferred, to: state.preferred) != nil else { continue }
+
+            var updated = state
+            updated.isUsingFallback = false
+            updated.lastPreferredFailure = nil
+            states[id] = updated
+            return
+        }
+    }
+
+    private func replacingBase(of url: URL, from base: String, to replacement: String) -> URL? {
+        replacingBase(of: normalized(url), from: base, to: replacement)
+    }
+
+    private func replacingBase(of absolute: String, from base: String, to replacement: String) -> URL? {
+        guard let suffix = suffix(of: absolute, after: base) else {
+            return nil
+        }
+
+        return URL(string: replacement + suffix)
+    }
+
+    private func suffix(of absolute: String, after base: String) -> String? {
+        if absolute == base {
+            return ""
+        }
+
+        if absolute.hasPrefix(base + "/") || absolute.hasPrefix(base + "?") {
+            return String(absolute.dropFirst(base.count))
+        }
+
+        return nil
+    }
+
+    private func normalized(_ url: URL) -> String {
+        var absolute = url.absoluteString
+
+        while absolute.hasSuffix("/") {
+            absolute.removeLast()
+        }
+
+        return absolute
     }
 }
 

--- a/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
@@ -5,7 +5,7 @@ extension InstanceEditView {
         do {
             isLoading = true
 
-            sanitizeInstanceUrl()
+            sanitizeInstanceUrls()
             try await validateInstance()
 
             if instance.label.isEmpty {
@@ -13,6 +13,7 @@ extension InstanceEditView {
             }
 
             settings.saveInstance(instance)
+            syncActiveInstance()
 
             #if os(iOS)
                 UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -29,6 +30,16 @@ extension InstanceEditView {
             self.error = error
         } catch {
             fatalError("Failed to save instance: Unhandled error")
+        }
+    }
+
+    func syncActiveInstance() {
+        if instance.type == .radarr, settings.radarrInstanceId == instance.id {
+            radarrInstance.switchTo(instance)
+        }
+
+        if instance.type == .sonarr, settings.sonarrInstanceId == instance.id {
+            sonarrInstance.switchTo(instance)
         }
     }
 
@@ -51,29 +62,45 @@ extension InstanceEditView {
         instance.url.isEmpty || instance.apiKey.isEmpty
     }
 
-    func sanitizeInstanceUrl() {
-        if let url = URL(string: instance.url) {
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+    func sanitizeInstanceUrls() {
+        instance.url = sanitizeUrl(instance.url)
+        instance.fallbackUrl = sanitizeUrl(instance.fallbackUrl)
+        instance.apiKey = instance.apiKey.trimmed()
+    }
+
+    func sanitizeUrl(_ value: String) -> String {
+        var sanitized = value.trimmed()
+
+        guard !sanitized.isEmpty else {
+            return ""
+        }
+
+        if var components = URLComponents(string: sanitized) {
+            components.scheme = components.scheme?.lowercased()
+            components.host = components.host?.lowercased()
 
             components.path = stripAfter("/system", in: components.path)
             components.path = stripAfter("/settings", in: components.path)
             components.path = stripAfter("/activity", in: components.path)
             components.path = stripAfter("/calendar", in: components.path)
+            components.path = stripAfter("/login", in: components.path)
+            components.query = nil
+            components.fragment = nil
 
             if let urlWithoutPath = components.url {
-                instance.url = urlWithoutPath.absoluteString
+                sanitized = urlWithoutPath.absoluteString
             }
         }
 
-        instance.url = instance.url.lowercased()
-
-        if instance.url.hasSuffix("/") {
-            instance.url = String(instance.url.dropLast())
+        if sanitized.hasSuffix("/") {
+            sanitized = String(sanitized.dropLast())
         }
+
+        return sanitized
     }
 
     func stripAfter(_ path: String, in string: String) -> String {
-        guard let range = string.range(of: path) else {
+        guard let range = string.range(of: path, options: [.caseInsensitive]) else {
             return string
         }
 
@@ -81,19 +108,13 @@ extension InstanceEditView {
     }
 
     func validateInstance() async throws {
-        guard instance.url.starts(with: /https?:\/\//) else {
-            throw InstanceError.urlSchemeMissing
+        try validateURL(instance.url, fallback: false)
+
+        if !instance.fallbackUrl.isEmpty {
+            try validateURL(instance.fallbackUrl, fallback: true)
         }
 
-        guard let url = URL(string: instance.url) else {
-            throw InstanceError.urlNotValid
-        }
-
-        if ["localhost", "127.0.0.1"].contains(url.host()) {
-            throw InstanceError.urlIsLocal
-        }
-
-        if instance.isPrivateIp(), await NetworkMonitor.shared.localNetworkDenied {
+        if instance.isPrivateIp(), instance.fallbackUrl.isEmpty, await NetworkMonitor.shared.localNetworkDenied {
             throw InstanceError.localNetworkDenied
         }
 
@@ -118,6 +139,20 @@ extension InstanceEditView {
         if let status {
             instance.name = status.instanceName
             instance.version = status.version
+        }
+    }
+
+    func validateURL(_ value: String, fallback: Bool) throws {
+        guard value.starts(with: /https?:\/\//) else {
+            throw fallback ? InstanceError.fallbackUrlSchemeMissing : InstanceError.urlSchemeMissing
+        }
+
+        guard let url = URL(string: value) else {
+            throw fallback ? InstanceError.fallbackUrlNotValid : InstanceError.urlNotValid
+        }
+
+        if ["localhost", "127.0.0.1"].contains(url.host()) {
+            throw fallback ? InstanceError.fallbackUrlIsLocal : InstanceError.urlIsLocal
         }
     }
 
@@ -173,6 +208,65 @@ extension InstanceEditView {
             }
         } else {
             instance.headers.append(InstanceHeader(name: value, value: ""))
+        }
+    }
+}
+
+enum InstanceError: Error {
+    case urlIsLocal
+    case urlNotValid
+    case urlSchemeMissing
+    case fallbackUrlIsLocal
+    case fallbackUrlNotValid
+    case fallbackUrlSchemeMissing
+    case labelEmpty
+    case localNetworkDenied
+    case badAppName(_ reported: String, _ expected: String)
+    case apiError(_ error: API.Error)
+}
+
+extension InstanceError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .urlIsLocal, .urlNotValid, .urlSchemeMissing:
+            return String(localized: "Invalid URL")
+        case .fallbackUrlIsLocal, .fallbackUrlNotValid, .fallbackUrlSchemeMissing:
+            return String(localized: "Invalid Fallback URL")
+        case .labelEmpty:
+            return String(localized: "Invalid Instance Label")
+        case .localNetworkDenied:
+            return String(localized: "Local Network Access Denied")
+        case .badAppName:
+            return String(localized: "Wrong Instance Type")
+        case .apiError(let error):
+            return error.errorDescription
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .urlIsLocal:
+            return String(localized: "URLs must be non-local, \"localhost\" and \"127.0.0.1\" will not work.")
+        case .urlNotValid:
+            return String(localized: "Enter a valid URL.")
+        case .urlSchemeMissing:
+            return String(localized: "URL must start with \"http://\" or \"https://\".")
+        case .fallbackUrlIsLocal:
+            return String(
+                localized: "Fallback URL must be non-local, \"localhost\" and \"127.0.0.1\" will not work."
+            )
+        case .fallbackUrlNotValid:
+            return String(localized: "Enter a valid fallback URL.")
+        case .fallbackUrlSchemeMissing:
+            return String(localized: "Fallback URL must start with \"http://\" or \"https://\".")
+        case .labelEmpty:
+            return String(localized: "Enter an instance label.")
+        case .localNetworkDenied:
+            return String(localized: "Local network access must be granted in System Settings to connect to instances on private IP addresses.")
+        case .badAppName(let reported, let expected):
+            return String(localized: "URL identified itself as a \(reported) instance, not a \(expected) instance.")
+        case .apiError(let error):
+            return error.recoverySuggestion
         }
     }
 }

--- a/Ruddarr/Views/Settings/InstanceEditView.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView.swift
@@ -100,8 +100,12 @@ struct InstanceEditView: View {
             typeField
             labelField
             urlField
+            fallbackUrlField
         } footer: {
-            Text("The URL used to access the \(instance.type.rawValue) web interface.")
+            Text(
+                "The preferred URL is tried first. If it is unreachable, Ruddarr will use " +
+                "the fallback URL and periodically retry the preferred URL."
+            )
                 #if os(macOS)
                 .foregroundStyle(.secondary)
                 .font(.footnote)
@@ -162,7 +166,7 @@ struct InstanceEditView: View {
             Text("URL")
                 .layoutPriority(2)
 
-            TextField(text: $instance.url, prompt: Text(verbatim: urlPlaceholder)) { EmptyView() }
+            TextField(text: $instance.url, prompt: Text(verbatim: "preferred")) { EmptyView() }
                 .truncationMode(.head)
                 .autocorrectionDisabled(true)
                 .textCase(.lowercase)
@@ -173,6 +177,25 @@ struct InstanceEditView: View {
                 .keyboardType(.URL)
                 #endif
 
+        }
+    }
+
+    var fallbackUrlField: some View {
+        HStack(spacing: 24) {
+            Text("Fallback")
+                .layoutPriority(2)
+
+            TextField(text: $instance.fallbackUrl, prompt: Text(verbatim: "(remote or DDNS URL)")) {
+                EmptyView()
+            }
+                .truncationMode(.head)
+                .autocorrectionDisabled(true)
+                .textCase(.lowercase)
+                #if os(iOS)
+                .multilineTextAlignment(.trailing)
+                .textInputAutocapitalization(.never)
+                .keyboardType(.URL)
+                #endif
         }
     }
 
@@ -260,13 +283,6 @@ struct InstanceEditView: View {
         }
     }
 
-    var urlPlaceholder: String {
-        switch instance.type {
-        case .radarr: "http://10.0.1.1:7878"
-        case .sonarr: "http://10.0.1.1:8989"
-        }
-    }
-
     var deleteButton: some View {
         Button(deviceType == .mac ? "Delete" : "Delete Instance", role: .destructive) {
             showingConfirmation = true
@@ -336,52 +352,6 @@ struct InstanceHeaderRow: View {
             #if os(iOS)
                 .textInputAutocapitalization(.never)
             #endif
-        }
-    }
-}
-
-enum InstanceError: Error {
-    case urlIsLocal
-    case urlNotValid
-    case urlSchemeMissing
-    case labelEmpty
-    case localNetworkDenied
-    case badAppName(_ reported: String, _ expected: String)
-    case apiError(_ error: API.Error)
-}
-
-extension InstanceError: LocalizedError {
-    var errorDescription: String? {
-        switch self {
-        case .urlIsLocal, .urlNotValid, .urlSchemeMissing:
-            return String(localized: "Invalid URL")
-        case .labelEmpty:
-            return String(localized: "Invalid Instance Label")
-        case .localNetworkDenied:
-            return String(localized: "Local Network Access Denied")
-        case .badAppName:
-            return String(localized: "Wrong Instance Type")
-        case .apiError(let error):
-            return error.errorDescription
-        }
-    }
-
-    var recoverySuggestion: String? {
-        switch self {
-        case .urlIsLocal:
-            return String(localized: "URLs must be non-local, \"localhost\" and \"127.0.0.1\" will not work.")
-        case .urlNotValid:
-            return String(localized: "Enter a valid URL.")
-        case .urlSchemeMissing:
-            return String(localized: "URL must start with \"http://\" or \"https://\".")
-        case .labelEmpty:
-            return String(localized: "Enter an instance label.")
-        case .localNetworkDenied:
-            return String(localized: "Local network access must be granted in System Settings to connect to instances on private IP addresses.")
-        case .badAppName(let reported, let expected):
-            return String(localized: "URL identified itself as a \(reported) instance, not a \(expected) instance.")
-        case .apiError(let error):
-            return error.recoverySuggestion
         }
     }
 }

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -4,10 +4,14 @@ import CloudKit
 import StoreKit
 
 struct InstanceView: View {
-    var instance: Instance
+    private let initialInstance: Instance
+
+    var instance: Instance {
+        settings.instanceById(initialInstance.id) ?? initialInstance
+    }
 
     init(instance: Instance) {
-        self.instance = instance
+        self.initialInstance = instance
         self._webhook = State(wrappedValue: InstanceWebhook(instance))
     }
 
@@ -93,6 +97,11 @@ struct InstanceView: View {
 
             LabeledContent("URL", value: instance.url)
                 .textSelection(.enabled)
+
+            if !instance.fallbackUrl.isEmpty {
+                LabeledContent("Fallback", value: instance.fallbackUrl)
+                    .textSelection(.enabled)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a Fallback URL field below the preferred instance URL in Settings.
- Retries API requests through the fallback URL when the preferred URL is unreachable.
- Keeps fallback routing runtime-only so the saved preferred and fallback URL fields are not rewritten automatically.
- Sanitizes and validates preferred/fallback URLs separately.

## Testing
- Built successfully with `xcodebuild`.
- Verified the new Settings field in the simulator.