### PR TITLE
Work around iOS 26.4+ search palette crash on scene transition

### DIFF
--- a/Ruddarr/Utilities/View.swift
+++ b/Ruddarr/Utilities/View.swift
@@ -6,6 +6,15 @@ extension View {
         self.modifier(OnBecomeActiveModifier(action: action))
     }
 
+    /// Dismisses an active `.searchable` field when the scene leaves the foreground.
+    ///
+    /// Works around an iOS 26.4+ crash where UIKit repositions the navigation bar
+    /// search palette (`_repositionPaletteWithNavigationBarHidden`) during a scene
+    /// transition while the search field is presented, trapping in the teardown block.
+    func dismissSearchWhenInactive(_ isPresented: Binding<Bool>) -> some View {
+        self.modifier(DismissSearchWhenInactiveModifier(isPresented: isPresented))
+    }
+
     func withAppState() -> some View {
         modifier(WithAppStateModifier())
     }
@@ -63,6 +72,27 @@ private struct OnBecomeActiveModifier: ViewModifier {
 
             Task { await action() }
         }
+    }
+#endif
+}
+
+private struct DismissSearchWhenInactiveModifier: ViewModifier {
+    @Binding var isPresented: Bool
+
+#if os(iOS)
+    @Environment(\.scenePhase) private var scenePhase
+
+    func body(content: Content) -> some View {
+        // Dismiss on `.inactive` (delivered before the `.background` transition)
+        // so there is no presented palette for UIKit to reposition mid-transition.
+        content.onChange(of: scenePhase) {
+            guard scenePhase != .active, isPresented else { return }
+            isPresented = false
+        }
+    }
+#else
+    func body(content: Content) -> some View {
+        content
     }
 #endif
 }

--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -43,6 +43,7 @@ struct MovieSearchView: View {
             isPresented: $searchPresented,
             placement: .drawerOrToolbar(.always)
         )
+        .dismissSearchWhenInactive($searchPresented)
         .disabled(instance.isVoid)
         .autocorrectionDisabled(true)
         .searchScopes($movieLookup.sort) {

--- a/Ruddarr/Views/MoviesView.swift
+++ b/Ruddarr/Views/MoviesView.swift
@@ -88,6 +88,7 @@ struct MoviesView: View {
                 isPresented: $searchPresented,
                 placement: .drawerOrToolbar
             )
+            .dismissSearchWhenInactive($searchPresented)
             .autocorrectionDisabled(true)
             .onChange(of: settings.radarrInstanceId, changeInstance)
             .onChange(of: sort.option, updateSortDirection)

--- a/Ruddarr/Views/Series/Search/SeriesSearchView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesSearchView.swift
@@ -41,6 +41,7 @@ struct SeriesSearchView: View {
             isPresented: $searchPresented,
             placement: .drawerOrToolbar(.always)
         )
+        .dismissSearchWhenInactive($searchPresented)
         .disabled(instance.isVoid)
         .autocorrectionDisabled(true)
         .searchScopes($seriesLookup.sort) {

--- a/Ruddarr/Views/SeriesView.swift
+++ b/Ruddarr/Views/SeriesView.swift
@@ -89,6 +89,7 @@ struct SeriesView: View {
                 isPresented: $searchPresented,
                 placement: .drawerOrToolbar
             )
+            .dismissSearchWhenInactive($searchPresented)
             .autocorrectionDisabled(true)
             .onChange(of: settings.sonarrInstanceId, changeInstance)
             .onChange(of: sort.option, updateSortDirection)


### PR DESCRIPTION
## Problem

Crash reports show an `EXC_BREAKPOINT` originating entirely in UIKit during a **scene lifecycle transition** (app backgrounding / orientation change):

```
UINavigationController _repositionPaletteWithNavigationBarHidden:duration:shouldUpdateNavigationItems:
UINavigationController _updateBarsForCurrentInterfaceOrientationAndForceBarLayout:
UIViewController _updateLayoutForStatusBarAndInterfaceOrientation
UITabBarController _updateLayoutForStatusBarAndInterfaceOrientation
... _UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:
```

The "palette" being repositioned is the navigation bar's `.searchable` search field. When the scene transitions while the search field is **presented**, UIKit redraws the palette and traps in the animation teardown block.

## Why now

This is an **Apple-side regression introduced in iOS 26.4** — not a code or SDK-build change on our side:
- Crashes are absent on ≤ 26.3 and first appear on 26.4, then continue across 26.4.1 / 26.4.2 / 26.5 / 26.5.1 / 26.6.
- The Sentry OS breakdown is spread roughly in proportion to version adoption, which is the fingerprint of a regression that entered at one OS version and was inherited by every later one (rather than something tied to a specific app release).

A Feedback Assistant report should be filed separately; this PR is the client-side mitigation so we don't have to wait on Apple.

## Fix

Adds a small reusable modifier, `dismissSearchWhenInactive(_:)`, that sets the searchable `isPresented` binding to `false` when the scene leaves `.active`. `.inactive` is delivered **before** the `.background` transition, so the search palette is torn down *before* the problematic relayout runs — leaving nothing for UIKit to reposition mid-transition.

Applied to the four screens that drive search via an `isPresented` binding:
- `MoviesView` (tab root)
- `SeriesView` (tab root)
- `MovieSearchView`
- `SeriesSearchView`

## Screens affected

All six `.searchable` usages render the navigation-bar drawer palette, so any can be on top when the scene transitions. The two tab roots are the highest-traffic and most likely culprits. Not yet covered:
- `MovieReleasesView` / `SeriesReleasesView` use a bindingless `.searchable(text:)` with `displayMode: .automatic` (palette only installed while actively searching/scrolled — lower exposure). Covering them would require introducing an `isPresented` state; happy to add if the Sentry breadcrumbs implicate them.

## Notes / how to verify

- This is a **potential** fix for a non-deterministic OS crash — it removes the trigger condition rather than the OS bug itself.
- Manual repro: open Movies/Series, present search, background the app (or rotate) — should no longer crash.
- Minor UX trade-off: an open search field is also dismissed on transient `.inactive` events (Control Center, notification banner). This is intentional and preferable to crashing.

https://claude.ai/code/session_01AoqntVbiYcJYqSfZs1Fhos

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoqntVbiYcJYqSfZs1Fhos)_