### PR TITLE
Add localization entries for downgrade notifications

### DIFF
--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -3198,18 +3198,6 @@
         }
       }
     },
-    "NOTIFICATION_EPISODE_DOWNGRADE_SUBTITLE" : {
-      "comment" : "Notification subtitle (series, season, episode)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (S%@ E%@)"
-          }
-        }
-      }
-    },
     "NOTIFICATION_EPISODE_DOWNLOAD" : {
       "comment" : "Notification title (instance name)",
       "extractionState" : "manual",
@@ -3482,18 +3470,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Downgraded from %1$@ to %2$@"
-          }
-        }
-      }
-    },
-    "NOTIFICATION_MOVIE_DOWNGRADE_SUBTITLE" : {
-      "comment" : "Notification subtitle (movie, year)",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (%@)"
           }
         }
       }

--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -3174,6 +3174,42 @@
         }
       }
     },
+    "NOTIFICATION_EPISODE_DOWNGRADE" : {
+      "comment" : "Notification title (instance name)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode Downgraded on %@"
+          }
+        }
+      }
+    },
+    "NOTIFICATION_EPISODE_DOWNGRADE_BODY" : {
+      "comment" : "Notification body (old quality, new quality)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downgraded from %1$@ to %2$@"
+          }
+        }
+      }
+    },
+    "NOTIFICATION_EPISODE_DOWNGRADE_SUBTITLE" : {
+      "comment" : "Notification subtitle (series, season, episode)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (S%@ E%@)"
+          }
+        }
+      }
+    },
     "NOTIFICATION_EPISODE_DOWNLOAD" : {
       "comment" : "Notification title (instance name)",
       "extractionState" : "manual",
@@ -3416,6 +3452,42 @@
     },
     "NOTIFICATION_MOVIE_DELETED_BODY" : {
       "comment" : "Notification body (title, year)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (%@)"
+          }
+        }
+      }
+    },
+    "NOTIFICATION_MOVIE_DOWNGRADE" : {
+      "comment" : "Notification title (instance name)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Movie Downgraded on %@"
+          }
+        }
+      }
+    },
+    "NOTIFICATION_MOVIE_DOWNGRADE_BODY" : {
+      "comment" : "Notification body (old quality, new quality)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downgraded from %1$@ to %2$@"
+          }
+        }
+      }
+    },
+    "NOTIFICATION_MOVIE_DOWNGRADE_SUBTITLE" : {
+      "comment" : "Notification subtitle (movie, year)",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {

--- a/Ruddarr/Services/Notifications.swift
+++ b/Ruddarr/Services/Notifications.swift
@@ -243,6 +243,12 @@ actor Notifications {
         String(format: localized("NOTIFICATION_MOVIE_UPGRADE_BODY"), "SDTV", "WEBDL-2160p"),
     ]
 
+    let movieDowngrade = [
+        String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE"), "Synology"),
+        String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE_SUBTITLE"), "Joker", "2024"),
+        String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE_BODY"), "WEBDL-2160p", "SDTV"),
+    ]
+
     let movieDeleted = [
         String(format: localized("NOTIFICATION_MOVIE_DELETED"), "Synology"),
         String(format: localized("NOTIFICATION_MOVIE_DELETED_BODY"), "Joker", "2024"),
@@ -291,6 +297,10 @@ actor Notifications {
 
             group("Upgrade")
             notification(movieUpgrade)
+            Divider().padding(.top, 6)
+
+            group("Downgrade")
+            notification(movieDowngrade)
             Divider().padding(.top, 6)
 
             group("Deleted")
@@ -343,6 +353,12 @@ actor Notifications {
         String(format: localized("NOTIFICATION_EPISODE_UPGRADE"), "Synology"),
         String(format: localized("NOTIFICATION_EPISODE_UPGRADE_SUBTITLE"), "Patriot", "2", "8"),
         String(format: localized("NOTIFICATION_EPISODE_UPGRADE_BODY"), "SDTV", "WEBDL-2160p"),
+    ]
+
+    let episodeDowngrade = [
+        String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE"), "Synology"),
+        String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE_SUBTITLE"), "Patriot", "2", "8"),
+        String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE_BODY"), "WEBDL-2160p", "SDTV"),
     ]
 
     let episodeFileDelete = [
@@ -400,6 +416,10 @@ actor Notifications {
 
             group("Upgrade (Episode)")
             notification(episodeUpgrade)
+            Divider().padding(.top, 6)
+
+            group("Downgrade (Episode)")
+            notification(episodeDowngrade)
             Divider().padding(.top, 6)
 
             group("Deleted (Episode File)")

--- a/Ruddarr/Services/Notifications.swift
+++ b/Ruddarr/Services/Notifications.swift
@@ -245,7 +245,6 @@ actor Notifications {
 
     let movieDowngrade = [
         String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE"), "Synology"),
-        String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE_SUBTITLE"), "Joker", "2024"),
         String(format: localized("NOTIFICATION_MOVIE_DOWNGRADE_BODY"), "WEBDL-2160p", "SDTV"),
     ]
 
@@ -357,7 +356,6 @@ actor Notifications {
 
     let episodeDowngrade = [
         String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE"), "Synology"),
-        String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE_SUBTITLE"), "Patriot", "2", "8"),
         String(format: localized("NOTIFICATION_EPISODE_DOWNGRADE_BODY"), "WEBDL-2160p", "SDTV"),
     ]
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,3 +1,4 @@
+- Added support for downgrade notifications
 - Added Brazilian Portuguese localization
 - Fixed various small iOS 27 issues
 - Fixed negative custom format scores showing a double minus sign


### PR DESCRIPTION
Adds movie and episode downgrade notification strings (title, subtitle,
body) to support the new downgrade notifications from apns-worker#19,
mirroring the existing upgrade entries. Also adds matching preview
entries in the notifications preview.