### PR TITLE
Fix missing top padding on media info sheet on macOS

### DIFF
--- a/Ruddarr/Views/Shared/MediaFileSheet.swift
+++ b/Ruddarr/Views/Shared/MediaFileSheet.swift
@@ -5,6 +5,7 @@ struct MediaFileSheet: View {
     var runtime: Int
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.deviceType) private var deviceType
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {
@@ -18,7 +19,7 @@ struct MediaFileSheet: View {
 
                     Spacer().frame(height: 42)
                 }
-                .padding(.top, reduceTransparency ? 0 : -52)
+                .padding(.top, deviceType == .mac ? 24 : (reduceTransparency ? 0 : -52))
                 .scenePadding(.horizontal)
             }
             #if os(macOS)

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -3,3 +3,4 @@
 - Clarified search placeholder text
 - Fixed various small iOS 27 issues
 - Fixed negative custom format scores double minus sign
+- Fixed missing top padding on media info sheet on macOS


### PR DESCRIPTION
## Summary
Fixed incorrect top padding calculation for the media file sheet on macOS by introducing device-type-aware padding logic.

## Changes
- Added `deviceType` environment variable to `MediaFileSheet` to detect the current platform
- Updated top padding calculation to apply `24pt` padding on macOS instead of the iOS-specific negative padding value
- The padding now conditionally uses:
  - `24pt` for macOS
  - `0pt` for iOS when reduce transparency is enabled
  - `-52pt` for iOS when reduce transparency is disabled

## Implementation Details
The fix addresses a layout issue where the media info sheet was not properly positioned on macOS. By checking the device type, we can apply platform-specific padding values that account for the different layout requirements between iOS and macOS.

https://claude.ai/code/session_01NevceEmeQJ11qzaGn6gApD