### PR TITLE
Sort monitored calendar items before unmonitored

### DIFF
--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -83,6 +83,10 @@ struct Episode: Identifiable, Codable, Equatable {
         episodeNumber == 1 && seasonNumber > 0
     }
 
+    var isMonitoredInCalendar: Bool {
+        monitored && series?.monitored != false
+    }
+
     var isDownloaded: Bool {
         hasFile
     }

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -148,6 +148,16 @@ struct CalendarView: View {
             }
         }
 
+        movies = movies.mapValues { items in
+            items.sorted {
+                if $0.monitored != $1.monitored {
+                    return $0.monitored
+                }
+
+                return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+            }
+        }
+
         return movies
     }
 
@@ -162,8 +172,21 @@ struct CalendarView: View {
                 dummy.calendarGroupCount = group.count
                 return dummy
             }.sorted {
-                ($0.airDateUtc ?? Date.distantPast, $0.episodeNumber) <
-                ($1.airDateUtc ?? Date.distantPast, $1.episodeNumber)
+                let lhsDate = $0.airDateUtc ?? Date.distantPast
+                let rhsDate = $1.airDateUtc ?? Date.distantPast
+
+                if lhsDate != rhsDate {
+                    return lhsDate < rhsDate
+                }
+
+                let lhsMonitored = $0.monitored && $0.series?.monitored != false
+                let rhsMonitored = $1.monitored && $1.series?.monitored != false
+
+                if lhsMonitored != rhsMonitored {
+                    return lhsMonitored
+                }
+
+                return $0.episodeNumber < $1.episodeNumber
             }
         }
 

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -34,6 +34,9 @@ struct CalendarView: View {
                 } else {
                     ScrollViewReader { proxy in
                         ScrollView {
+                            let moviesByDate = displayMovies ? filteredMovies : [:]
+                            let episodesByDate = displaySeries ? filteredEpisodes : [:]
+
                             LazyVGrid(columns: gridLayout, alignment: .leading, spacing: 0) {
                                 ForEach(calendar.dates, id: \.self) { timestamp in
                                     let date = Date(timeIntervalSince1970: timestamp)
@@ -44,7 +47,7 @@ struct CalendarView: View {
                                     }
 
                                     CalendarDate(date: date).offset(x: -6)
-                                    media(for: timestamp, date: date)
+                                    media(date: date, movies: moviesByDate[timestamp], episodes: episodesByDate[timestamp])
                                 }
                             }
 
@@ -134,87 +137,65 @@ struct CalendarView: View {
     }
 
     var filteredMovies: [TimeInterval: [Movie]] {
-        var movies = calendar.movies
-
-        if displayedInstance != .all {
-            movies = movies.mapValues { items in
-                items.filter { $0.instanceId?.isEqual(to: displayedInstance) == true }
+        calendar.movies.mapValues { items in
+            let filtered = items.filter { movie in
+                if displayedInstance != .all, movie.instanceId?.isEqual(to: displayedInstance) != true { return false }
+                if onlyMonitored, !movie.monitored { return false }
+                return true
             }
+
+            guard filtered.count > 1 else { return filtered }
+            return filtered.sorted(by: areMoviesInCalendarOrder)
         }
-
-        if onlyMonitored {
-            movies = movies.mapValues { items in
-                items.filter { $0.monitored }
-            }
-        }
-
-        movies = movies.mapValues { items in
-            items.sorted {
-                if $0.monitored != $1.monitored {
-                    return $0.monitored
-                }
-
-                return $0.title.localizedStandardCompare($1.title) == .orderedAscending
-            }
-        }
-
-        return movies
     }
 
     var filteredEpisodes: [TimeInterval: [Episode]] {
-        var episodes = calendar.episodes
+        calendar.episodes.mapValues { items in
+            let filtered = items.filter(includeEpisodeInCalendar)
 
-        episodes = episodes.mapValues { items in
-            let grouped = Dictionary(grouping: items, by: \.calendarGroup)
+            guard filtered.count > 1 else { return filtered }
 
-            return grouped.values.compactMap { group in
-                guard var dummy = group.first else { return group[0] }
-                dummy.calendarGroupCount = group.count
-                return dummy
-            }.sorted {
-                let lhsDate = $0.airDateUtc ?? Date.distantPast
-                let rhsDate = $1.airDateUtc ?? Date.distantPast
-
-                if lhsDate != rhsDate {
-                    return lhsDate < rhsDate
-                }
-
-                let lhsMonitored = $0.monitored && $0.series?.monitored != false
-                let rhsMonitored = $1.monitored && $1.series?.monitored != false
-
-                if lhsMonitored != rhsMonitored {
-                    return lhsMonitored
-                }
-
-                return $0.episodeNumber < $1.episodeNumber
+            let grouped = Dictionary(grouping: filtered, by: \.calendarGroup)
+            let episodes = grouped.values.compactMap { group -> Episode? in
+                guard var episode = group.first else { return nil }
+                episode.calendarGroupCount = group.count
+                return episode
             }
+
+            guard episodes.count > 1 else { return episodes }
+            return episodes.sorted(by: areEpisodesInCalendarOrder)
+        }
+    }
+
+    func includeEpisodeInCalendar(_ episode: Episode) -> Bool {
+        if displayedInstance != .all, episode.instanceId?.isEqual(to: displayedInstance) != true { return false }
+        if onlyMonitored, !episode.isMonitoredInCalendar { return false }
+        if onlyPremieres, !episode.isPremiere { return false }
+        if hideSpecials, episode.isSpecial { return false }
+        return true
+    }
+
+    func areMoviesInCalendarOrder(_ lhs: Movie, _ rhs: Movie) -> Bool {
+        if lhs.monitored != rhs.monitored {
+            return lhs.monitored
         }
 
-        if displayedInstance != .all {
-            episodes = episodes.mapValues { items in
-                items.filter { $0.instanceId?.isEqual(to: displayedInstance) == true }
-            }
+        return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
+    }
+
+    func areEpisodesInCalendarOrder(_ lhs: Episode, _ rhs: Episode) -> Bool {
+        let lhsDate = lhs.airDateUtc ?? .distantPast
+        let rhsDate = rhs.airDateUtc ?? .distantPast
+
+        if lhsDate != rhsDate {
+            return lhsDate < rhsDate
         }
 
-        if onlyMonitored {
-            episodes = episodes.mapValues { items in
-                items.filter { $0.monitored }
-            }
+        if lhs.isMonitoredInCalendar != rhs.isMonitoredInCalendar {
+            return lhs.isMonitoredInCalendar
         }
 
-        if onlyPremieres {
-            episodes = episodes.mapValues { items in
-                items.filter { $0.isPremiere }
-            }
-        }
-
-        if hideSpecials {
-            episodes = episodes.mapValues { items in
-                items.filter { !$0.isSpecial }
-            }
-        }
-
-        return episodes
+        return lhs.episodeNumber < rhs.episodeNumber
     }
 
     func load(force: Bool = false) async {
@@ -260,15 +241,15 @@ struct CalendarView: View {
         scrollView?.scrollTo(timestamp, anchor: .center)
     }
 
-    func media(for timestamp: TimeInterval, date: Date) -> some View {
+    func media(date: Date, movies: [Movie]?, episodes: [Episode]?) -> some View {
         VStack(spacing: 8) {
-            if displayMovies, let movies = filteredMovies[timestamp] {
+            if let movies {
                 ForEach(movies) { movie in
                     CalendarMovie(date: date, movie: movie)
                 }
             }
 
-            if displaySeries, let episodes = filteredEpisodes[timestamp] {
+            if let episodes {
                 ForEach(episodes) { episode in
                     CalendarEpisode(episode: episode)
                 }

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,5 +1,6 @@
 - Added support for downgrade notifications
 - Added Brazilian Portuguese localization
+- Improved calendar filtering/ordering 
 - Clarified search placeholder text
 - Fixed poster size when screen sharing
 - Fixed negative custom format scores double minus sign


### PR DESCRIPTION
When calendar items share the same date and time, list monitored
items before unmonitored ones.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cj8FVmMa6oGKA39KWTRBGx