### PR TITLE
Update Trakt links and add Callsheet support for episodes

### DIFF
--- a/Ruddarr/Views/Movies/MovieLinks.swift
+++ b/Ruddarr/Views/Movies/MovieLinks.swift
@@ -30,7 +30,7 @@ struct MovieLinks: View {
         let query = movie.imdbId ?? movie.title
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
 
-        return "https://app.trakt.tv/search?q=\(encoded)"
+        return "https://app.trakt.tv/search?m=movie&q=\(encoded)"
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Movies/MovieLinks.swift
+++ b/Ruddarr/Views/Movies/MovieLinks.swift
@@ -27,10 +27,11 @@ struct MovieLinks: View {
     }
 
     var traktUrl: String {
-        let query = movie.imdbId ?? movie.title
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        if let imdbId = movie.imdbId {
+            return "https://app.trakt.tv/movies/\(imdbId)"
+        }
 
-        return "https://app.trakt.tv/search?m=movie&q=\(encoded)"
+        return "https://app.trakt.tv/search?m=movie&q=\(encodedTitle)"
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Movies/MovieLinks.swift
+++ b/Ruddarr/Views/Movies/MovieLinks.swift
@@ -27,7 +27,10 @@ struct MovieLinks: View {
     }
 
     var traktUrl: String {
-        "https://trakt.tv/search/tmdb/\(movie.tmdbId)?id_type=movie"
+        let query = movie.imdbId ?? movie.title
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+
+        return "https://app.trakt.tv/search?q=\(encoded)"
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Series/EpisodeContextMenu.swift
+++ b/Ruddarr/Views/Series/EpisodeContextMenu.swift
@@ -7,8 +7,6 @@ struct EpisodeContextMenu: View {
 
     var body: some View {
         Group {
-            link(name: "Trakt", url: traktUrl)
-
             if encodedTitle != nil {
                 link(name: "IMDb", url: imdbUrl)
             }
@@ -45,16 +43,6 @@ struct EpisodeContextMenu: View {
         episode.title?.addingPercentEncoding(
             withAllowedCharacters: .urlQueryAllowed
         )
-    }
-
-    var traktUrl: String {
-        // Trakt's v3 web app dropped external-id redirects; episodes have no IMDb
-        // id, so fall back to the series (IMDb id when known, otherwise its title).
-        let series: Series? = instance.series.byId(episode.seriesId)
-        let query = series?.imdbId ?? series?.title ?? episode.titleLabel
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-
-        return "https://app.trakt.tv/search?q=\(encoded)"
     }
 
     var callsheet: String? {

--- a/Ruddarr/Views/Series/EpisodeContextMenu.swift
+++ b/Ruddarr/Views/Series/EpisodeContextMenu.swift
@@ -13,6 +13,10 @@ struct EpisodeContextMenu: View {
                 link(name: "IMDb", url: imdbUrl)
             }
 
+            if let callsheetUrl = callsheet {
+                link(name: "Callsheet", url: callsheetUrl)
+            }
+
             Divider()
 
             Button("Automatic Search", systemImage: "magnifyingglass") {
@@ -51,6 +55,23 @@ struct EpisodeContextMenu: View {
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
 
         return "https://app.trakt.tv/search?q=\(encoded)"
+    }
+
+    var callsheet: String? {
+        #if os(iOS)
+        let series: Series? = instance.series.byId(episode.seriesId)
+
+        if let tmdbId = series?.tmdbId {
+            // Callsheet deep-links down to the season level, not individual episodes.
+            let url = "callsheet://open/tv/\(tmdbId)/season/\(episode.seasonNumber)"
+
+            if UIApplication.shared.canOpenURL(URL(string: url)!) {
+                return url
+            }
+        }
+        #endif
+
+        return nil
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Series/EpisodeContextMenu.swift
+++ b/Ruddarr/Views/Series/EpisodeContextMenu.swift
@@ -44,7 +44,13 @@ struct EpisodeContextMenu: View {
     }
 
     var traktUrl: String {
-        "https://trakt.tv/search/tvdb/\(episode.tvdbId)?id_type=episode"
+        // Trakt's v3 web app dropped external-id redirects; episodes have no IMDb
+        // id, so fall back to the series (IMDb id when known, otherwise its title).
+        let series: Series? = instance.series.byId(episode.seriesId)
+        let query = series?.imdbId ?? series?.title ?? episode.titleLabel
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+
+        return "https://app.trakt.tv/search?q=\(encoded)"
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Series/EpisodeContextMenu.swift
+++ b/Ruddarr/Views/Series/EpisodeContextMenu.swift
@@ -7,6 +7,10 @@ struct EpisodeContextMenu: View {
 
     var body: some View {
         Group {
+            if let traktUrl {
+                link(name: "Trakt", url: traktUrl)
+            }
+
             if encodedTitle != nil {
                 link(name: "IMDb", url: imdbUrl)
             }
@@ -43,6 +47,14 @@ struct EpisodeContextMenu: View {
         episode.title?.addingPercentEncoding(
             withAllowedCharacters: .urlQueryAllowed
         )
+    }
+
+    var traktUrl: String? {
+        guard let imdbId = instance.series.byId(episode.seriesId)?.imdbId else {
+            return nil
+        }
+
+        return "https://app.trakt.tv/shows/\(imdbId)/seasons/\(episode.seasonNumber)/episodes/\(episode.episodeNumber)"
     }
 
     var callsheet: String? {

--- a/Ruddarr/Views/Series/EpisodeContextMenu.swift
+++ b/Ruddarr/Views/Series/EpisodeContextMenu.swift
@@ -58,7 +58,10 @@ struct EpisodeContextMenu: View {
     }
 
     var callsheet: String? {
-        #if os(iOS)
+        #if !os(iOS)
+            return nil
+        #endif
+
         let series: Series? = instance.series.byId(episode.seriesId)
 
         if let tmdbId = series?.tmdbId {
@@ -69,9 +72,6 @@ struct EpisodeContextMenu: View {
                 return url
             }
         }
-        #endif
-
-        return nil
     }
 
     var imdbUrl: String {

--- a/Ruddarr/Views/Series/SeriesLinks.swift
+++ b/Ruddarr/Views/Series/SeriesLinks.swift
@@ -30,7 +30,7 @@ struct SeriesLinks: View {
         let query = series.imdbId ?? series.title
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
 
-        return "https://app.trakt.tv/search?q=\(encoded)"
+        return "https://app.trakt.tv/search?m=show&q=\(encoded)"
     }
 
     var tvdbUrl: String {

--- a/Ruddarr/Views/Series/SeriesLinks.swift
+++ b/Ruddarr/Views/Series/SeriesLinks.swift
@@ -27,7 +27,10 @@ struct SeriesLinks: View {
     }
 
     var traktUrl: String {
-        "https://trakt.tv/search/tvdb/\(series.tvdbId)?id_type=show"
+        let query = series.imdbId ?? series.title
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+
+        return "https://app.trakt.tv/search?q=\(encoded)"
     }
 
     var tvdbUrl: String {

--- a/Ruddarr/Views/Series/SeriesLinks.swift
+++ b/Ruddarr/Views/Series/SeriesLinks.swift
@@ -27,10 +27,11 @@ struct SeriesLinks: View {
     }
 
     var traktUrl: String {
-        let query = series.imdbId ?? series.title
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        if let imdbId = series.imdbId {
+            return "https://app.trakt.tv/shows/\(imdbId)"
+        }
 
-        return "https://app.trakt.tv/search?m=show&q=\(encoded)"
+        return "https://app.trakt.tv/search?m=show&q=\(encodedTitle)"
     }
 
     var tvdbUrl: String {

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,8 +1,9 @@
 - Added support for downgrade notifications
 - Added Brazilian Portuguese localization
+- Added episode links to Callsheet
 - Improved calendar filtering/ordering 
 - Clarified search placeholder text
-- Fixed broken Trakt links after their website redesign
+- Fixed broken Trakt links
 - Fixed poster size when screen sharing
 - Fixed negative custom format scores double minus sign
 - Fixed missing top padding on media info sheet on macOS

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -2,6 +2,7 @@
 - Added Brazilian Portuguese localization
 - Improved calendar filtering/ordering 
 - Clarified search placeholder text
+- Fixed broken Trakt links after their website redesign
 - Fixed poster size when screen sharing
 - Fixed negative custom format scores double minus sign
 - Fixed missing top padding on media info sheet on macOS


### PR DESCRIPTION
## Summary
This PR updates Trakt URL generation to use the new app.trakt.tv search endpoint and adds support for deep-linking to the Callsheet app for episode viewing on iOS.

## Key Changes
- **Trakt URL Updates**: Modified Trakt link generation in `EpisodeContextMenu`, `MovieLinks`, and `SeriesLinks` to use the new `app.trakt.tv/search` endpoint instead of the deprecated external-id redirect URLs
  - For episodes: Falls back to series IMDb ID, then series title, then episode title as search query
  - For movies and series: Uses IMDb ID when available, otherwise falls back to title
  - All queries are properly URL-encoded

- **Callsheet Integration**: Added optional `callsheet` property to `EpisodeContextMenu` that:
  - Only available on iOS (`#if os(iOS)`)
  - Deep-links to Callsheet app using TMDB ID and season number
  - Checks if the Callsheet app is installed before returning the URL
  - Returns `nil` if app is not available or TMDB ID is missing

- **UI Enhancement**: Added Callsheet link to the episode context menu when available

## Implementation Details
- The Trakt v3 web app no longer supports external-id redirects, requiring a switch to text-based search
- Callsheet deep-linking uses the format: `callsheet://open/tv/{tmdbId}/season/{seasonNumber}`
- URL availability is checked using `UIApplication.shared.canOpenURL()` before exposing the link

https://claude.ai/code/session_01XdaU39sc2HBQMCuBfvwLUd