### PR TITLE
Simplify movie search discovery grid check

### DIFF
--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -7,10 +7,6 @@ struct MovieSearchView: View {
 
     @Environment(RadarrInstance.self) private var instance
 
-    private var shouldShowDiscoveryGrid: Bool {
-        instance.lookup.isEmpty() && searchQuery.isEmpty
-    }
-
     var body: some View {
         @Bindable var discovery = Discovery.shared
         @Bindable var movieLookup = instance.lookup
@@ -85,6 +81,10 @@ struct MovieSearchView: View {
                 ContentUnavailableView.search(text: searchQuery)
             }
         }
+    }
+
+    var shouldShowDiscoveryGrid: Bool {
+        instance.lookup.isEmpty() && searchQuery.isEmpty
     }
 
     func performSearch(debounced: Bool = false) {

--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -7,12 +7,16 @@ struct MovieSearchView: View {
 
     @Environment(RadarrInstance.self) private var instance
 
+    private var shouldShowDiscoveryGrid: Bool {
+        instance.lookup.isEmpty() && searchQuery.isEmpty
+    }
+
     var body: some View {
         @Bindable var discovery = Discovery.shared
         @Bindable var movieLookup = instance.lookup
 
         ScrollView {
-            if movieLookup.sortedItems.isEmpty && searchQuery.isEmpty {
+            if shouldShowDiscoveryGrid {
                 MediaGrid(items: discovery.movies) { item in
                     DiscoveryGridPoster(item: item)
                 } header: {


### PR DESCRIPTION
Applies the same change as #673 to `MovieSearchView`.

- Extracts the discovery-grid condition into a `shouldShowDiscoveryGrid` computed property (mirroring the `SeriesSearchView` refactor).
- Uses `instance.lookup.isEmpty()` instead of `movieLookup.sortedItems.isEmpty`, so emptiness is determined without forcing a full sort of the lookup results. This matches the overlay logic already used in the same view (`instance.lookup.isEmpty()`).

`isEmpty()` is semantically identical to `sortedItems.isEmpty` (`(items ?? []).isEmpty`), since sorting never changes emptiness — but skips the work the `sortedItems` getter flags with `// consider caching this for performance`. The `else` branch keeps `movieLookup.sortedItems`, where the sort is needed for display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)