### PR TITLE
Use prominent Liquid Glass background for active toolbar filters

### DIFF
--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -92,6 +92,11 @@ extension WhatsNew {
             subtitle: "Releases with dual audio are now included in the Multilingual language filter."
         ),
         .init(
+            image: "line.3.horizontal.decrease",
+            title: "Filter Indicator",
+            subtitle: "Active filters now highlight the toolbar button with a tinted background."
+        ),
+        .init(
             image: "ladybug",
             title: "Fixes & Improvements",
             subtitle: "Various internal code improvements, bug fixes, and refinements for macOS."

--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -92,11 +92,6 @@ extension WhatsNew {
             subtitle: "Releases with dual audio are now included in the Multilingual language filter."
         ),
         .init(
-            image: "line.3.horizontal.decrease",
-            title: "Filter Indicator",
-            subtitle: "Active filters now highlight the toolbar button with a tinted background."
-        ),
-        .init(
             image: "ladybug",
             title: "Fixes & Improvements",
             subtitle: "Various internal code improvements, bug fixes, and refinements for macOS."

--- a/Ruddarr/Views/Activity/ActivityView+Toolbar.swift
+++ b/Ruddarr/Views/Activity/ActivityView+Toolbar.swift
@@ -74,15 +74,9 @@ extension ActivityView {
                 Toggle("Issues", systemImage: "exclamationmark.triangle", isOn: $sort.issues)
             }
         } label: {
-            if sort.hasFilter {
-                Image("filters.badge")
-                    .offset(y: 3)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(settings.theme.tint, .primary)
-            } else {
-                Image(systemName: "line.3.horizontal.decrease")
-            }
+            Image(systemName: "line.3.horizontal.decrease")
         }
+        .toolbarFilterIndicator(active: sort.hasFilter, tint: settings.theme.tint)
     }
 
     var instancePicker: some View {

--- a/Ruddarr/Views/Activity/HistoryView.swift
+++ b/Ruddarr/Views/Activity/HistoryView.swift
@@ -113,15 +113,12 @@ struct HistoryView: View {
                 }
                 .pickerStyle(.inline)
             } label: {
-                if displayedInstance != .all || displayedEventType != .all {
-                    Image("filters.badge")
-                        .offset(y: 3)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(settings.theme.tint, .primary)
-                } else {
-                    Image(systemName: "line.3.horizontal.decrease")
-                }
+                Image(systemName: "line.3.horizontal.decrease")
             }
+            .toolbarFilterIndicator(
+                active: displayedInstance != .all || displayedEventType != .all,
+                tint: settings.theme.tint
+            )
             .menuIndicator(.hidden)
         }
     }

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -342,15 +342,12 @@ struct CalendarView: View {
                     }
                 }
             } label: {
-                if displayedMediaType != .all || onlyPremieres || onlyMonitored || hideSpecials {
-                    Image("filters.badge")
-                        .offset(y: 3)
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.tint, .primary)
-                } else {
-                    Image(systemName: "line.3.horizontal.decrease")
-                }
+                Image(systemName: "line.3.horizontal.decrease")
             }
+            .toolbarFilterIndicator(
+                active: displayedMediaType != .all || onlyPremieres || onlyMonitored || hideSpecials,
+                tint: settings.theme.tint
+            )
             .menuIndicator(.hidden)
         }
     }

--- a/Ruddarr/Views/Movies/MoviesView+Toolbar.swift
+++ b/Ruddarr/Views/Movies/MoviesView+Toolbar.swift
@@ -51,15 +51,12 @@ extension MoviesView {
                 }
             }.pickerStyle(.menu)
         } label: {
-            if sort.filter != .all || sort.folder != .all {
-                Image("filters.badge")
-                    .offset(y: 3)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(.tint, .primary)
-            } else {
-                Image(systemName: "line.3.horizontal.decrease")
-            }
+            Image(systemName: "line.3.horizontal.decrease")
         }
+        .toolbarFilterIndicator(
+            active: sort.filter != .all || sort.folder != .all,
+            tint: settings.theme.tint
+        )
     }
 
     var toolbarSortingButton: some View {

--- a/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
+++ b/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
@@ -173,15 +173,9 @@ extension MovieReleasesView {
                 )
             }
         } label: {
-            if sort.hasFilter {
-                Image("filters.badge")
-                    .offset(y: 3)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(.tint, .primary)
-            } else{
-                Image(systemName: "line.3.horizontal.decrease")
-            }
+            Image(systemName: "line.3.horizontal.decrease")
         }
+        .toolbarFilterIndicator(active: sort.hasFilter, tint: settings.theme.tint)
         .menuIndicator(.hidden)
     }
 

--- a/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
+++ b/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
@@ -173,15 +173,9 @@ extension SeriesReleasesView {
                 Toggle("Original", systemImage: "character.bubble", isOn: $sort.originalLanguage)
             }
         } label: {
-            if sort.hasFilter {
-                Image("filters.badge")
-                    .offset(y: 3)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(.tint, .primary)
-            } else {
-                Image(systemName: "line.3.horizontal.decrease")
-            }
+            Image(systemName: "line.3.horizontal.decrease")
         }
+        .toolbarFilterIndicator(active: sort.hasFilter, tint: settings.theme.tint)
         .menuIndicator(.hidden)
     }
 

--- a/Ruddarr/Views/Series/SeriesView+Toolbar.swift
+++ b/Ruddarr/Views/Series/SeriesView+Toolbar.swift
@@ -51,15 +51,12 @@ extension SeriesView {
                 }
             }.pickerStyle(.menu)
         } label: {
-            if sort.filter != .all || sort.folder != .all {
-                Image("filters.badge")
-                    .offset(y: 3)
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(.tint, .primary)
-            } else {
-                Image(systemName: "line.3.horizontal.decrease")
-            }
+            Image(systemName: "line.3.horizontal.decrease")
         }
+        .toolbarFilterIndicator(
+            active: sort.filter != .all || sort.folder != .all,
+            tint: settings.theme.tint
+        )
     }
 
     var toolbarSortingButton: some View {

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -44,8 +44,9 @@ extension View {
     func toolbarFilterIndicator(active: Bool, tint: Color) -> some View {
         if active {
             self
-                .tint(tint)
+                .menuStyle(.button)
                 .buttonStyle(.glassProminent)
+                .tint(tint)
         } else {
             self
         }

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -35,3 +35,19 @@ struct ToolbarActionButton: View {
         Image(systemName: "ellipsis")
     }
 }
+
+extension View {
+    /// Indicates an active toolbar filter using a prominent, tinted Liquid Glass
+    /// background (iOS 26) instead of a custom badge glyph. Inactive buttons keep
+    /// the standard toolbar glass styling.
+    @ViewBuilder
+    func toolbarFilterIndicator(active: Bool, tint: Color) -> some View {
+        if active {
+            self
+                .tint(tint)
+                .buttonStyle(.glassProminent)
+        } else {
+            self
+        }
+    }
+}

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,2 +1,3 @@
 - Display Quick Look of posters
+- Highlight toolbar filter button when a filter is active
 - Dozens of internal code improvements


### PR DESCRIPTION
## What

Indicate an **active filter** on toolbar buttons with the native iOS 26 **Liquid Glass** prominent style (a tinted glass background) instead of swapping in the custom `filters.badge` glyph.

Before, an active filter swapped the icon to a badged asset (`Image("filters.badge")` with palette rendering). Now the button keeps a single `line.3.horizontal.decrease` glyph and the system renders a tinted prominent capsule behind it when a filter is active — matching the standard iOS 26 toolbar behavior.

## How

Adds a small reusable helper in `Views/Shared/Toolbar.swift`:

```swift
extension View {
    @ViewBuilder
    func toolbarFilterIndicator(active: Bool, tint: Color) -> some View {
        if active {
            self.tint(tint).buttonStyle(.glassProminent)
        } else {
            self
        }
    }
}
```

When inactive the button is left untouched (default toolbar glass). When active it gets `.buttonStyle(.glassProminent)` tinted with `settings.theme.tint`, so the accent color reads through regardless of any local `.tint(.primary)` override (e.g. Activity).

## Where (every toolbar button that had an indicator)

- `SeriesView+Toolbar.swift`
- `MoviesView+Toolbar.swift`
- `ActivityView+Toolbar.swift`
- `CalendarView.swift`
- `HistoryView.swift`
- `SeriesReleasesView.swift`
- `MovieReleasesView.swift`

Sort buttons were left as-is since they have no active-state indicator.

## Notes

- The `filters.badge` symbol asset is now unused by code but left in place — happy to remove it in this PR if you'd prefer.
- I couldn't build/run this in the web environment (no Xcode), so the prominent-glass rendering on `Menu` labels should be verified on an iOS 26 simulator/device. If `Menu` doesn't pick up `.buttonStyle(.glassProminent)` as expected, the alternative is wrapping the label in an explicit `Button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpL9ggLhtSnCgCpJ8HjpkR)_