### PR TITLE
Improve calendar detail sheet presentation

### DIFF
--- a/Ruddarr/Dependencies/API/API+Live.swift
+++ b/Ruddarr/Dependencies/API/API+Live.swift
@@ -26,7 +26,9 @@ extension API {
                 .appending(path: "/api/v3/movie")
                 .appending(path: String(movieId))
 
-            return try await request(url: url, headers: instance.auth)
+            var movie: Movie = try await request(url: url, headers: instance.auth)
+            movie.instanceId = instance.id
+            return movie
         }, getMovieHistory: { movieId, instance in
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/history/movie")
@@ -95,7 +97,7 @@ extension API {
                 .appending(queryItems: [.init(name: "seriesId", value: String(seriesId))])
 
             var episodes: [Episode] = try await request(url: url, headers: instance.auth)
-            for i in episodes.indices { episodes[i].instanceId = instance.id }
+            for i in episodes.indices { episodes[i].instanceId = instance.id; episodes[i].series?.instanceId = instance.id }
             return episodes
         }, fetchEpisodeFiles: { seriesId, instance in
             let url = try instance.baseURL()
@@ -120,12 +122,14 @@ extension API {
             }
 
             return try await request(url: url, headers: instance.auth, timeout: instance.timeout(.releaseSearch))
-        }, getSeries: { series, instance in
+        }, getSeries: { seriesId, instance in
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/series")
-                .appending(path: String(series))
+                .appending(path: String(seriesId))
 
-            return try await request(url: url, headers: instance.auth)
+            var series: Series = try await request(url: url, headers: instance.auth)
+            series.instanceId = instance.id
+            return series
         }, addSeries: { series, instance in
             let url = try instance.baseURL()
                 .appending(path: "/api/v3/series")
@@ -214,7 +218,7 @@ extension API {
                 ])
 
             var episodes: [Episode] = try await request(url: url, headers: instance.auth, timeout: instance.timeout(.slow))
-            for i in episodes.indices { episodes[i].instanceId = instance.id }
+            for i in episodes.indices { episodes[i].instanceId = instance.id; episodes[i].series?.instanceId = instance.id }
             return episodes
         }, command: { command, instance in
             let url = try instance.baseURL()

--- a/Ruddarr/Dependencies/QuickActions.swift
+++ b/Ruddarr/Dependencies/QuickActions.swift
@@ -69,10 +69,6 @@ struct QuickActions {
         }
     }
 
-    var openSeries: () -> Void = {
-        dependencies.router.selectedTab = .series
-    }
-
     var openSeriesSearch: (String) -> Void = { query in
         var searchText: String = query
 
@@ -117,8 +113,9 @@ extension QuickActions {
         case openMovies
         case openMovie(_ id: Movie.ID, _ instance: String?)
         case addMovie(_ query: String = "")
-        case openSeries
-        case openSeriesItem(_ id: Movie.ID, _ season: Season.ID?, _ episode: Episode.ID?, _ instance: String?)
+        case openSeries(_ id: Series.ID, _ instance: String?)
+        case openSeason(_ id: Series.ID, _ season: Season.ID, _ instance: String?)
+        case openEpisode(_ id: Series.ID, _ season: Season.ID, _ episode: Episode.ID, _ instance: String?)
         case addSeries(_ query: String = "")
 
         func callAsFunction() {
@@ -135,10 +132,12 @@ extension QuickActions {
                 dependencies.quickActions.openMovieSearch(query)
             case .openMovie(let movie, let instance):
                 dependencies.quickActions.openMovie(movie, instance)
-            case .openSeries:
-                dependencies.quickActions.openSeries()
-            case .openSeriesItem(let series, let season, let episode, let instance):
-                dependencies.quickActions.openSeries(series, season, episode, instance)
+            case .openSeries(let id, let instance):
+                dependencies.quickActions.openSeries(id, nil, nil, instance)
+            case .openSeason(let id, let season, let instance):
+                dependencies.quickActions.openSeries(id, season, nil, instance)
+            case .openEpisode(let id, let season, let episode, let instance):
+                dependencies.quickActions.openSeries(id, season, episode, instance)
             case .addSeries(let query):
                 dependencies.quickActions.openSeriesSearch(query)
             }
@@ -183,12 +182,38 @@ extension QuickActions.Deeplink {
             self = .addSeries(value)
         case _ where action.hasPrefix("series/open/"):
             guard let id = Series.ID(value) else { throw unsupportedURL }
-            let seasonId = components.queryItems?.first { $0.name == "season" }?.value
-            let episodeId = components.queryItems?.first { $0.name == "episode" }?.value
+            let season = (components.queryItems?.first { $0.name == "season" }?.value).flatMap { Int($0) }
+            let episode = (components.queryItems?.first { $0.name == "episode" }?.value).flatMap { Int($0) }
             let instance = components.queryItems?.first { $0.name == "instance" }?.value
-            self = .openSeriesItem(id, Int(seasonId ?? ""), Int(episodeId ?? ""), instance)
+
+            if let season, let episode {
+                self = .openEpisode(id, season, episode, instance)
+            } else if let season {
+                self = .openSeason(id, season, instance)
+            } else {
+                self = .openSeries(id, instance)
+            }
         default:
             throw unsupportedURL
+        }
+    }
+
+    var url: URL? {
+        switch self {
+        case .openMovie(let id, let instance):
+            var url = "ruddarr://movies/open/\(id)?instance=\(instance ?? "")"
+            return URL(string: url)
+        case .openSeries(let id, let instance):
+            var url = "ruddarr://series/open/\(id)?instance=\(instance ?? "")"
+            return URL(string: url)
+        case .openSeason(let id, let season, let instance):
+            var url = "ruddarr://series/open/\(id)?season=\(season)&instance=\(instance ?? "")"
+            return URL(string: url)
+        case .openEpisode(let id, let season, let episode, let instance):
+            var url = "ruddarr://series/open/\(id)?season=\(season)&episode=\(episode)&instance=\(instance ?? "")"
+            return URL(string: url)
+        default:
+            return nil
         }
     }
 }

--- a/Ruddarr/Models/Movies/Movie.swift
+++ b/Ruddarr/Models/Movies/Movie.swift
@@ -122,7 +122,7 @@ struct Movie: Media, Identifiable, Equatable, Codable {
 
     var deeplink: URL? {
         guard let instanceId else { return nil }
-        return URL(string: "ruddarr://movies/open/\(id)?instance=\(instanceId.uuidString)")
+        return QuickActions.Deeplink.openMovie(id, instanceId.uuidString).url
     }
 
     var stateLabel: String {

--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -34,7 +34,7 @@ struct Episode: Identifiable, Codable, Equatable {
     let sceneSeasonNumber: Int?
     let unverifiedSceneNumbering: Bool
 
-    let series: Series?
+    var series: Series?
 
     var calendarGroupCount: Int?
 

--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -49,13 +49,11 @@ struct Episode: Identifiable, Codable, Equatable {
     var deeplink: URL? {
         guard let instanceId else { return nil }
 
-        var deeplink = "ruddarr://series/open/\(seriesId)?season=\(seasonNumber)&instance=\(instanceId.uuidString)"
-
-        if !isGroupedInCalendar {
-            deeplink.append("&episode=\(episodeNumber)")
+        if isGroupedInCalendar {
+            return QuickActions.Deeplink.openSeason(seriesId, seasonNumber, instanceId.uuidString).url
         }
 
-        return URL(string: deeplink)
+        return QuickActions.Deeplink.openEpisode(seriesId, seasonNumber, episodeNumber, instanceId.uuidString).url
     }
 
     var titleLabel: String {

--- a/Ruddarr/Ruddarr.swift
+++ b/Ruddarr/Ruddarr.swift
@@ -63,11 +63,17 @@ struct Ruddarr: App {
 
         let parts = identifier.split(separator: ":").map(String.init) // `<type>:<id>:<instance>`
 
-        switch parts[0] {
-        case "movie": openDeeplink(url: URL(string: "ruddarr://movies/open/\(parts[1])?instance=\(parts[2])")!)
-        case "series": openDeeplink(url: URL(string: "ruddarr://series/open/\(parts[1])?instance=\(parts[2])")!)
-        default: leaveBreadcrumb(.error, category: "spotlight", message: "Invalid identifier", data: ["openSearchableItem": identifier])
+        let deeplink: QuickActions.Deeplink? = switch parts[0] {
+        case "movie": Movie.ID(parts[1]).map { .openMovie($0, parts[2]) }
+        case "series": Series.ID(parts[1]).map { .openSeries($0, parts[2]) }
+        default: nil
         }
+
+        guard let deeplink else {
+            return leaveBreadcrumb(.error, category: "spotlight", message: "Invalid identifier", data: ["openSearchableItem": identifier])
+        }
+
+        deeplink()
     }
 }
 

--- a/Ruddarr/Utilities/View.swift
+++ b/Ruddarr/Utilities/View.swift
@@ -40,6 +40,13 @@ extension View {
     func presentationDetents(dynamic: Set<PresentationDetent>) -> some View {
         self.modifier(DynamicPresentationDetents(detents: dynamic))
     }
+
+    func presentationDetents(
+        dynamic: Set<PresentationDetent>,
+        selection: Binding<PresentationDetent>
+    ) -> some View {
+        self.modifier(DynamicPresentationDetents(detents: dynamic, selection: selection))
+    }
 }
 
 private struct OnBecomeActiveModifier: ViewModifier {
@@ -127,11 +134,17 @@ struct HideIconOnMac: ViewModifier {
 
 private struct DynamicPresentationDetents: ViewModifier {
     var detents: Set<PresentationDetent>
+    var selection: Binding<PresentationDetent>?
 
     @Environment(\.sizeCategory) var sizeCategory
 
+    @ViewBuilder
     func body(content: Content) -> some View {
-        content.presentationDetents(adjustedDetents)
+        if let selection {
+            content.presentationDetents(adjustedDetents, selection: selection)
+        } else {
+            content.presentationDetents(adjustedDetents)
+        }
     }
 
     var adjustedDetents: Set<PresentationDetent> {

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -48,9 +48,10 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
                 .accessibilityLabel("Close")
             }
 
-            if showsOpenButton {
+            if let deeplink {
                 ToolbarItem(placement: .bottomBar) {
                     Button("Open", systemImage: "arrow.up.forward.app") {
+                        try? QuickActions.Deeplink(url: deeplink)()
                         inCalendarSheet.dismiss()
                     }
                     .tint(.primary)
@@ -163,7 +164,9 @@ extension View {
     @ViewBuilder
     func calendarSheetToolbar(_ enabled: Bool = true) -> some View {
         if enabled {
-            toolbar { CalendarSheetAwareToolbar() }
+            toolbar {
+                CalendarSheetAwareToolbar()
+            }
         } else {
             self
         }

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -32,6 +32,11 @@ struct CalendarDetailSheet: View {
 }
 
 struct CalendarSheetAwareToolbar: ToolbarContent {
+    /// Whether the "Open" button (deep-links to the selected item) is shown.
+    /// Only the destination view for the selection should offer it — e.g. the
+    /// episode view, not the intermediate series or season views.
+    var showsOpenButton: Bool = true
+
     @Environment(\.inCalendarSheet) private var inCalendarSheet
 
     var body: some ToolbarContent {
@@ -46,12 +51,17 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
                 .accessibilityLabel("Close")
             }
 
-            ToolbarItem(placement: .automatic) {
-                Button("Open", systemImage: "arrow.up.forward.app") {
-                    inCalendarSheet.selection.jumpToTab()
-                    inCalendarSheet.dismiss()
+            if showsOpenButton {
+                ToolbarItem(placement: .bottomBar) {
+                    Button("Open", systemImage: "arrow.up.forward.app") {
+                        inCalendarSheet.selection.jumpToTab()
+                        inCalendarSheet.dismiss()
+                    }
+                    .tint(.primary)
                 }
-                .tint(.primary)
+
+                // Pin the "Open" button to the left of the bottom bar.
+                ToolbarSpacer(.flexible, placement: .bottomBar)
             }
         }
     }

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -34,6 +34,7 @@ struct CalendarDetailSheet: View {
 struct CalendarSheetAwareToolbar: ToolbarContent {
     var deeplink: URL?
 
+    @Environment(\.deviceType) private var deviceType
     @Environment(\.inCalendarSheet) private var inCalendarSheet
 
     var body: some ToolbarContent {
@@ -49,7 +50,7 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
             }
 
             if let deeplink {
-                ToolbarItem(placement: .bottomBar) {
+                ToolbarItem(placement: deviceType == .phone ? .bottomBar : .automatic) {
                     Button("Open", systemImage: "arrow.up.forward.app") {
                         try? QuickActions.Deeplink(url: deeplink)()
                         inCalendarSheet.dismiss()
@@ -57,7 +58,7 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
                     .tint(.primary)
                 }
 
-                ToolbarSpacer(.flexible, placement: .bottomBar)
+                ToolbarSpacer(.flexible, placement: deviceType == .phone ? .bottomBar : .automatic)
             }
         }
     }

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -9,13 +9,13 @@ struct CalendarDetailSheet: View {
         switch selection {
         case .movie(let movie):
             if let instance = instance(movie.instanceId) {
-                CalendarMovieSheet(selection: selection, movie: movie, instance: instance)
+                CalendarMovieSheet(movie: movie, instance: instance)
             } else {
                 unavailable
             }
         case .episode(let episode):
             if let instance = instance(episode.instanceId), episode.series != nil {
-                CalendarEpisodeSheet(selection: selection, episode: episode, instance: instance)
+                CalendarEpisodeSheet(episode: episode, instance: instance)
             } else {
                 unavailable
             }
@@ -32,10 +32,7 @@ struct CalendarDetailSheet: View {
 }
 
 struct CalendarSheetAwareToolbar: ToolbarContent {
-    /// Whether the "Open" button (deep-links to the selected item) is shown.
-    /// Only the destination view for the selection should offer it — e.g. the
-    /// episode view, not the intermediate series or season views.
-    var showsOpenButton: Bool = true
+    var deeplink: URL?
 
     @Environment(\.inCalendarSheet) private var inCalendarSheet
 
@@ -54,13 +51,11 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
             if showsOpenButton {
                 ToolbarItem(placement: .bottomBar) {
                     Button("Open", systemImage: "arrow.up.forward.app") {
-                        inCalendarSheet.selection.jumpToTab()
                         inCalendarSheet.dismiss()
                     }
                     .tint(.primary)
                 }
 
-                // Pin the "Open" button to the left of the bottom bar.
                 ToolbarSpacer(.flexible, placement: .bottomBar)
             }
         }
@@ -69,20 +64,18 @@ struct CalendarSheetAwareToolbar: ToolbarContent {
 
 private struct CalendarMovieSheet: View {
     private let movieId: Movie.ID
-    private let selection: CalendarSelection
 
     @State private var path = NavigationPath()
     @State private var instance: RadarrInstance
 
     @Environment(\.dismiss) private var dismiss
 
-    init(selection: CalendarSelection, movie: Movie, instance model: Instance) {
+    init(movie: Movie, instance model: Instance) {
         let instance = RadarrInstance(model)
         instance.movies.items = [movie]
         instance.movies.cachedItems = [movie]
         instance.movies.itemsCount = 1
 
-        self.selection = selection
         self.movieId = movie.id
         self._instance = State(initialValue: instance)
     }
@@ -95,7 +88,7 @@ private struct CalendarMovieSheet: View {
                 }
         }
         .environment(instance)
-        .inCalendarSheet(selection: selection) {
+        .inCalendarSheet {
             dismiss()
         }
         .displayToasts()
@@ -111,14 +104,13 @@ private struct CalendarMovieSheet: View {
 
 private struct CalendarEpisodeSheet: View {
     private let seriesId: Series.ID
-    private let selection: CalendarSelection
 
     @State private var path: NavigationPath
     @State private var instance: SonarrInstance
 
     @Environment(\.dismiss) private var dismiss
 
-    init(selection: CalendarSelection, episode: Episode, instance model: Instance) {
+    init(episode: Episode, instance model: Instance) {
         let instance = SonarrInstance(model)
 
         if let series = episode.series {
@@ -129,7 +121,6 @@ private struct CalendarEpisodeSheet: View {
 
         instance.episodes.items = [episode]
 
-        self.selection = selection
         self.seriesId = episode.seriesId
 
         var path = NavigationPath()
@@ -151,7 +142,7 @@ private struct CalendarEpisodeSheet: View {
                 }
         }
         .environment(instance)
-        .inCalendarSheet(selection: selection) {
+        .inCalendarSheet {
             dismiss()
         }
         .displayToasts()

--- a/Ruddarr/Views/Calendar/CalendarSheetContext.swift
+++ b/Ruddarr/Views/Calendar/CalendarSheetContext.swift
@@ -27,7 +27,6 @@ enum CalendarSelection: Identifiable {
 }
 
 struct CalendarSheetContext {
-    let selection: CalendarSelection
     let dismiss: @MainActor () -> Void
 }
 
@@ -43,7 +42,7 @@ extension EnvironmentValues {
 }
 
 extension View {
-    func inCalendarSheet(selection: CalendarSelection, dismiss: @escaping @MainActor () -> Void) -> some View {
-        environment(\.inCalendarSheet, CalendarSheetContext(selection: selection, dismiss: dismiss))
+    func inCalendarSheet(dismiss: @escaping @MainActor () -> Void) -> some View {
+        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss))
     }
 }

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -9,7 +9,6 @@ struct CalendarView: View {
     @State private var hideCalendarView: Bool = true
     @State private var isRetrying: Bool = false
     @State private var selectedMedia: CalendarSelection?
-    @State private var sheetDetent: PresentationDetent = .fraction(0.8)
 
     @AppStorage("calendarMonitored", store: dependencies.store) private var onlyMonitored: Bool = false
     @AppStorage("calendarSpecials", store: dependencies.store) private var hideSpecials: Bool = false
@@ -19,6 +18,7 @@ struct CalendarView: View {
     @State private var displayedMediaType: CalendarMediaType = .all
 
     @EnvironmentObject var settings: AppSettings
+    @Environment(\.deviceType) private var deviceType
 
     private let firstWeekday = Calendar.current.firstWeekday
 
@@ -119,7 +119,8 @@ struct CalendarView: View {
             #if os(iOS)
                 .sheet(item: $selectedMedia) { selection in
                     CalendarDetailSheet(selection: selection)
-                        .presentationDetents(dynamic: [.medium, .fraction(0.8), .large], selection: $sheetDetent)
+                        .presentationDetents(dynamic: deviceType == .pad ? [.large] : [.fraction(0.8), .large])
+                        .presentationSizing(.page)
                         .presentationDragIndicator(.visible)
                         .presentationBackground(.sheetBackground)
                 }
@@ -386,7 +387,6 @@ struct CalendarView: View {
 
     func open(_ selection: CalendarSelection) {
         #if os(iOS)
-            sheetDetent = .fraction(0.8) // always open at the default height
             selectedMedia = selection
         #else
             selection.jumpToTab()

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -9,6 +9,7 @@ struct CalendarView: View {
     @State private var hideCalendarView: Bool = true
     @State private var isRetrying: Bool = false
     @State private var selectedMedia: CalendarSelection?
+    @State private var sheetDetent: PresentationDetent = .fraction(0.8)
 
     @AppStorage("calendarMonitored", store: dependencies.store) private var onlyMonitored: Bool = false
     @AppStorage("calendarSpecials", store: dependencies.store) private var hideSpecials: Bool = false
@@ -118,7 +119,8 @@ struct CalendarView: View {
             #if os(iOS)
                 .sheet(item: $selectedMedia) { selection in
                     CalendarDetailSheet(selection: selection)
-                        .presentationDetents([.large])
+                        .presentationDetents(dynamic: [.medium, .fraction(0.8), .large], selection: $sheetDetent)
+                        .presentationDragIndicator(.visible)
                         .presentationBackground(.sheetBackground)
                 }
             #endif
@@ -384,6 +386,7 @@ struct CalendarView: View {
 
     func open(_ selection: CalendarSelection) {
         #if os(iOS)
+            sheetDetent = .fraction(0.8) // always open at the default height
             selectedMedia = selection
         #else
             selection.jumpToTab()

--- a/Ruddarr/Views/Movies/MovieView.swift
+++ b/Ruddarr/Views/Movies/MovieView.swift
@@ -25,7 +25,7 @@ struct MovieView: View {
         }
         .safeNavigationBarTitleDisplayMode(.inline)
         .toolbar {
-            CalendarSheetAwareToolbar()
+            CalendarSheetAwareToolbar(deeplink: movie.deeplink)
             toolbarMonitorButton
             toolbarMenu
         }

--- a/Ruddarr/Views/Series/EpisodeView.swift
+++ b/Ruddarr/Views/Series/EpisodeView.swift
@@ -56,7 +56,7 @@ struct EpisodeView: View {
         .navigationTitle(navigationTitle)
         .safeNavigationBarTitleDisplayMode(.inline)
         .toolbar {
-            CalendarSheetAwareToolbar()
+            CalendarSheetAwareToolbar(deeplink: episode.deeplink)
             toolbarMonitorButton
             toolbarMenu
         }

--- a/Ruddarr/Views/Series/SeasonView.swift
+++ b/Ruddarr/Views/Series/SeasonView.swift
@@ -36,7 +36,7 @@ struct SeasonView: View {
             .padding(.vertical)
         #endif
         .toolbar {
-            CalendarSheetAwareToolbar(showsOpenButton: false)
+            CalendarSheetAwareToolbar(deeplink: deeplink)
             toolbarMonitorButton
             toolbarMenu
         }
@@ -78,6 +78,11 @@ struct SeasonView: View {
         } message: {
             Text("This will permanently erase all episode files of this season.")
         }.tint(nil)
+    }
+
+    var deeplink: URL? {
+        guard let instanceId = series.instanceId else { return nil }
+        return QuickActions.Deeplink.openSeason(series.id, seasonId, instanceId.uuidString).url
     }
 
     var season: Season {

--- a/Ruddarr/Views/Series/SeasonView.swift
+++ b/Ruddarr/Views/Series/SeasonView.swift
@@ -36,7 +36,7 @@ struct SeasonView: View {
             .padding(.vertical)
         #endif
         .toolbar {
-            CalendarSheetAwareToolbar()
+            CalendarSheetAwareToolbar(showsOpenButton: false)
             toolbarMonitorButton
             toolbarMenu
         }

--- a/Ruddarr/Views/Series/SeriesItemView.swift
+++ b/Ruddarr/Views/Series/SeriesItemView.swift
@@ -25,7 +25,7 @@ struct SeriesDetailView: View {
         }
         .safeNavigationBarTitleDisplayMode(.inline)
         .toolbar {
-            CalendarSheetAwareToolbar()
+            CalendarSheetAwareToolbar(showsOpenButton: false)
             toolbarMonitorButton
             toolbarMenu
         }

--- a/Ruddarr/Views/Series/SeriesItemView.swift
+++ b/Ruddarr/Views/Series/SeriesItemView.swift
@@ -25,7 +25,7 @@ struct SeriesDetailView: View {
         }
         .safeNavigationBarTitleDisplayMode(.inline)
         .toolbar {
-            CalendarSheetAwareToolbar(showsOpenButton: false)
+            CalendarSheetAwareToolbar(deeplink: deeplink)
             toolbarMonitorButton
             toolbarMenu
         }
@@ -111,6 +111,11 @@ struct SeriesDetailView: View {
                 }
             #endif
         }
+    }
+
+    var deeplink: URL? {
+        guard let instanceId = series.instanceId else { return nil }
+        return QuickActions.Deeplink.openSeries(series.id, instanceId.uuidString).url
     }
 
     var refreshAction: some View {


### PR DESCRIPTION
Improvements to the calendar detail sheet (built on the existing Calendar detail-sheet feature):

- **Open button → bottom bar.** The "Open" deeplink button moves from the top toolbar into the bottom bar (left side).
- **Open button only on the destination view.** It now appears only on the episode/movie view, not the intermediate series or season views (where deeplinking to the selected episode would be confusing). Controlled by a new `showsOpenButton` flag on `CalendarSheetAwareToolbar`.
- **Drag handle.** The sheet now shows a grab handle.
- **Resizable heights.** The sheet offers `.medium` / `.fraction(0.8)` / `.large`, opening at `0.8` and resetting to that height on each open. Adds a `presentationDetents(dynamic:selection:)` overload so the existing accessibility detent-adjustment is preserved.

Scope: this PR intentionally contains **only** the calendar-sheet changes — the toolbar active-filter indicator work lives on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TytXqiRUcpLANJTNaTFc6X