### PR TITLE
Name local poster copies after media title and year

### DIFF
--- a/Ruddarr/Models/Movies/Movie.swift
+++ b/Ruddarr/Models/Movies/Movie.swift
@@ -202,6 +202,10 @@ struct Movie: Media, Identifiable, Equatable, Codable {
         return nil
     }
 
+    var posterFilename: String {
+        year > 0 ? "\(title) (\(year))" : title
+    }
+
     var isDownloaded: Bool {
         movieFile != nil
     }

--- a/Ruddarr/Models/Series/Series.swift
+++ b/Ruddarr/Models/Series/Series.swift
@@ -146,6 +146,10 @@ struct Series: Media, Identifiable, Equatable, Codable {
         return nil
     }
 
+    var posterFilename: String {
+        year > 0 ? "\(title) (\(year))" : title
+    }
+
     var genreLabel: String {
         genres.prefix(3)
             .map { $0.replacingOccurrences(of: "Science Fiction", with: "Sci-Fi") }

--- a/Ruddarr/Services/Images.swift
+++ b/Ruddarr/Services/Images.swift
@@ -54,6 +54,13 @@ class Images {
         return thumbnail
     }
 
+    private static func thumbnailPath(_ key: String) -> URL? {
+        FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("com.ruddarr.images/\(sha1(of: key))")
+    }
+
     static func localCopy(of remote: String?, named filename: String? = nil) async -> URL? {
         guard let remote, let url = URL(string: remote) else { return nil }
 
@@ -61,11 +68,18 @@ class Images {
             return cached
         }
 
-        let file = localCopyDestination(for: url, named: filename)
+        let file = localCopyPath(for: url, named: filename)
 
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
+
+            try FileManager.default.createDirectory(
+                at: file.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
             try data.write(to: file)
+
             return file
         } catch {
             return nil
@@ -75,45 +89,38 @@ class Images {
     static func hasLocalCopy(of remote: String?, named filename: String? = nil) -> URL? {
         guard let remote, let url = URL(string: remote) else { return nil }
 
-        let file = localCopyDestination(for: url, named: filename)
+        let file = localCopyPath(for: url, named: filename)
 
         return FileManager.default.fileExists(atPath: file.path) ? file : nil
     }
 
-    private static func localCopyDestination(for url: URL, named filename: String?) -> URL {
+    private static func localCopyPath(for url: URL, named filename: String?) -> URL {
         let pathExtension = url.pathExtension.isEmpty ? "jpg" : url.pathExtension
 
+        let illegal = CharacterSet(charactersIn: "/\\:*?\"<>|").union(.newlines)
+
         let name = filename
-            .map { sanitizeFilename($0) }
+            .map {
+                $0.components(separatedBy: illegal)
+                    .joined(separator: " ")
+                    .replacingOccurrences(of: "  ", with: " ")
+                    .trimmingCharacters(in: .whitespaces)
+            }
             .flatMap { $0.isEmpty ? nil : $0 }
             ?? url.deletingPathExtension().lastPathComponent
 
         return FileManager.default.temporaryDirectory
+            .appendingPathComponent(sha1(of: url.absoluteString))
             .appendingPathComponent(name)
             .appendingPathExtension(pathExtension)
     }
 
-    private static func sanitizeFilename(_ name: String) -> String {
-        let illegal = CharacterSet(charactersIn: "/\\:*?\"<>|").union(.newlines)
-
-        return name
-            .components(separatedBy: illegal)
-            .joined(separator: " ")
-            .replacingOccurrences(of: "  ", with: " ")
-            .trimmingCharacters(in: .whitespaces)
-    }
-
-    private static func thumbnailPath(_ key: String) -> URL? {
-        let cacheKeyHash = Insecure.SHA1
-            .hash(data: Data(key.utf8))
+    private static func sha1(of value: String) -> String {
+        Insecure.SHA1
+            .hash(data: Data(value.utf8))
             .prefix(Insecure.SHA1.byteCount)
             .map { String(format: "%02hhx", $0) }
             .joined()
-
-        return FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)
-            .first?
-            .appendingPathComponent("com.ruddarr.images/\(cacheKeyHash)")
     }
 }
 

--- a/Ruddarr/Services/Images.swift
+++ b/Ruddarr/Services/Images.swift
@@ -54,19 +54,14 @@ class Images {
         return thumbnail
     }
 
-    static func localCopy(of remote: String?) async -> URL? {
+    static func localCopy(of remote: String?, named filename: String? = nil) async -> URL? {
         guard let remote, let url = URL(string: remote) else { return nil }
 
-        if let cached = hasLocalCopy(of: remote) {
+        if let cached = hasLocalCopy(of: remote, named: filename) {
             return cached
         }
 
-        var file = FileManager.default.temporaryDirectory
-            .appendingPathComponent(url.lastPathComponent)
-
-        if file.pathExtension.isEmpty {
-            file.appendPathExtension("jpg")
-        }
+        let file = localCopyDestination(for: url, named: filename)
 
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
@@ -77,17 +72,35 @@ class Images {
         }
     }
 
-    static func hasLocalCopy(of remote: String?) -> URL? {
+    static func hasLocalCopy(of remote: String?, named filename: String? = nil) -> URL? {
         guard let remote, let url = URL(string: remote) else { return nil }
 
-        var file = FileManager.default.temporaryDirectory
-            .appendingPathComponent(url.lastPathComponent)
-
-        if file.pathExtension.isEmpty {
-            file.appendPathExtension("jpg")
-        }
+        let file = localCopyDestination(for: url, named: filename)
 
         return FileManager.default.fileExists(atPath: file.path) ? file : nil
+    }
+
+    private static func localCopyDestination(for url: URL, named filename: String?) -> URL {
+        let pathExtension = url.pathExtension.isEmpty ? "jpg" : url.pathExtension
+
+        let name = filename
+            .map { sanitizeFilename($0) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+            ?? url.deletingPathExtension().lastPathComponent
+
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent(name)
+            .appendingPathExtension(pathExtension)
+    }
+
+    private static func sanitizeFilename(_ name: String) -> String {
+        let illegal = CharacterSet(charactersIn: "/\\:*?\"<>|").union(.newlines)
+
+        return name
+            .components(separatedBy: illegal)
+            .joined(separator: " ")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespaces)
     }
 
     private static func thumbnailPath(_ key: String) -> URL? {

--- a/Ruddarr/Views/Movies/MovieDetails+Overview.swift
+++ b/Ruddarr/Views/Movies/MovieDetails+Overview.swift
@@ -11,7 +11,7 @@ extension MovieDetails {
                 .modifier(MediaDetailsPosterModifier())
                 .clipped()
                 .clipShape(RoundedRectangle(cornerRadius: 14))
-                .posterQuickLook(movie.remotePoster)
+                .posterQuickLook(movie.remotePoster, named: movie.posterFilename)
                 .padding(.trailing, deviceType == .phone ? 8 : 16)
 
             VStack(alignment: .leading, spacing: 0) {

--- a/Ruddarr/Views/Series/SeriesDetails+Overview.swift
+++ b/Ruddarr/Views/Series/SeriesDetails+Overview.swift
@@ -11,7 +11,7 @@ extension SeriesDetails {
                 .modifier(MediaDetailsPosterModifier())
                 .clipped()
                 .clipShape(RoundedRectangle(cornerRadius: 14))
-                .posterQuickLook(series.remotePoster)
+                .posterQuickLook(series.remotePoster, named: series.posterFilename)
                 .padding(.trailing, deviceType == .phone ? 8 : 16)
 
             VStack(alignment: .leading, spacing: 0) {

--- a/Ruddarr/Views/Shared/PosterQuickLook.swift
+++ b/Ruddarr/Views/Shared/PosterQuickLook.swift
@@ -3,6 +3,7 @@ import QuickLook
 
 struct PosterQuickLook: ViewModifier {
     let remote: String?
+    let filename: String?
 
     @State private var url: URL?
     @State private var isLoading = false
@@ -11,12 +12,12 @@ struct PosterQuickLook: ViewModifier {
         content
             .onTapGesture {
                 Task {
-                    if Images.hasLocalCopy(of: remote) == nil {
+                    if Images.hasLocalCopy(of: remote, named: filename) == nil {
                         isLoading = true
                     }
 
                     defer { isLoading = false }
-                    url = await Images.localCopy(of: remote)
+                    url = await Images.localCopy(of: remote, named: filename)
                 }
             }
             .allowsHitTesting(!isLoading)
@@ -36,7 +37,7 @@ struct PosterQuickLook: ViewModifier {
 }
 
 extension View {
-    func posterQuickLook(_ remote: String?) -> some View {
-        modifier(PosterQuickLook(remote: remote))
+    func posterQuickLook(_ remote: String?, named filename: String? = nil) -> some View {
+        modifier(PosterQuickLook(remote: remote, filename: filename))
     }
 }


### PR DESCRIPTION
`Images.localCopy` now accepts an optional filename so the temporary copy
used for Quick Look is named like "The Matrix (2000).jpg" instead of the
opaque remote URL component. Movie and Series pass a sanitized title+year
filename via a new `posterFilename` helper.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MRypY6N9dKmp9VR5o4P4YA