### PR TITLE
Speed up media grids at scale (image pipeline, poster sizes, sorting, search)

### DIFF
--- a/Ruddarr/Services/Images.swift
+++ b/Ruddarr/Services/Images.swift
@@ -32,15 +32,10 @@ class Images {
         )
     }
 
-    /// Maps a TMDB poster URL to a smaller official rendition so we don't download and decode the
-    /// multi-megabyte `original`. Other hosts (TheTVDB, self-hosted artwork) pass through untouched —
-    /// Nuke's resize processor still caps them at the display size. Full-resolution QuickLook/share
-    /// reads `remotePoster` directly.
     private static func sized(_ url: URL) -> URL {
         guard let host = url.host else { return url }
 
-        // TMDB: official width-constrained renditions (configuration `poster_sizes`). w780 ≥ our
-        // retina resize target (250pt × 3 = 750px), so Nuke downscales — never upscales — on @3x.
+        // use w780 as source for TMDb posters
         if host.hasSuffix("image.tmdb.org") {
             let sized = url.absoluteString.replacingOccurrences(of: "/t/p/original/", with: "/t/p/w780/")
             return URL(string: sized) ?? url

--- a/Ruddarr/Services/Images.swift
+++ b/Ruddarr/Services/Images.swift
@@ -19,7 +19,7 @@ class Images {
         _ priority: ImageRequest.Priority = .normal
     ) -> ImageRequest {
         ImageRequest(
-            urlRequest: URLRequest(url: url, timeoutInterval: 5),
+            urlRequest: URLRequest(url: sized(url), timeoutInterval: 5),
             processors: [
                 .resize(
                     size: type.size,
@@ -30,6 +30,23 @@ class Images {
             ],
             priority: priority
         )
+    }
+
+    /// Maps a TMDB poster URL to a smaller official rendition so we don't download and decode the
+    /// multi-megabyte `original`. Other hosts (TheTVDB, self-hosted artwork) pass through untouched —
+    /// Nuke's resize processor still caps them at the display size. Full-resolution QuickLook/share
+    /// reads `remotePoster` directly.
+    private static func sized(_ url: URL) -> URL {
+        guard let host = url.host else { return url }
+
+        // TMDB: official width-constrained renditions (configuration `poster_sizes`). w780 ≥ our
+        // retina resize target (250pt × 3 = 750px), so Nuke downscales — never upscales — on @3x.
+        if host.hasSuffix("image.tmdb.org") {
+            let sized = url.absoluteString.replacingOccurrences(of: "/t/p/original/", with: "/t/p/w780/")
+            return URL(string: sized) ?? url
+        }
+
+        return url
     }
 
     static func thumbnail(_ poster: String?, _ priority: ImageRequest.Priority = .normal) async -> URL? {


### PR DESCRIPTION
## Summary

Performance pass on the movie/series grids, profiled against a stress library (**81,333 movies / 24,182 series**). Five focused changes across the image pipeline, poster sizing, sorting, and search. Builds green for iOS Simulator.

## Image size changes

| Provider | Before | After | Why |
|---|---|---|---|
| **TMDB** | `/t/p/original/` (~2000px, multi-MB) | `/t/p/w780/` (780px, ~100–150 KB) | Official `poster_sizes` rendition; ≥ the @3x Nuke resize target (250pt × 3 = 750px), so it **downscales — never upscales** |
| **TheTVDB** | `original` (~680×1000) | `original` (unchanged) | No official thumbnail field reaches us via Sonarr; Nuke resizes the original down to display size |

Earlier iterations tried TMDB `w500` and a TheTVDB `_t` thumbnail. `_t` was dropped — it's an unofficial CDN convention (the v4 contract is the `thumbnail` field, which Sonarr doesn't pass through), and it wasn't idempotent or query-safe.

**No resolution loss:** every poster is resized by Nuke to `ImageType.poster.size × screenScale` — at most 750×1125px (@3x). `w780` (780px) exceeds that, so it yields the *same* cached image `original` produced; only the download and decode shrank. Full-resolution QuickLook/share is unaffected (reads `remotePoster` directly).

## Image pipeline

- **Shared `ImagePipeline`** — `Images.pipeline()` constructed a new pipeline + `URLSession` + `DataCache` on every poster render. Now a single `Images.shared` → request coalescing, a global concurrency limit, connection reuse, no per-render setup churn.
- **Request priority** — grid posters load at `.normal`, the detail poster at `.veryHigh`, so a fast scroll no longer floods the queue at max priority (now meaningful thanks to the shared pipeline).

## Sorting & search

- **Precompute sort keys** — derived keys (`ratingScore` / `sortYear` / dates) were recomputed on every comparison (O(n log n)). Now computed once per item and index-sorted. Over 81k items: byYear **220 ms → 13 ms**, byRating **151 ms → 10 ms** (off-main, but it gates the grid update). Ordering verified identical to the prior comparator, including series `byNextAiring`'s inverted direction.
- **Debounce library search** — typing re-ran a full 81k locale-aware scan per keystroke (~120 ms each); now debounced 250 ms via the existing `SearchRequest` primitive.

## Testing

- `xcodebuild` succeeds for the iOS Simulator at every step.
- Sort ordering and the TMDB/TheTVDB URL handling validated against the real stress dataset (native benchmark + edge-case checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZNakTzd2qm4ffcjBmefxX
