### PR TITLE
Distinguish blocked imports in queue status symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Display download queue status in various places
+- Display queue status for movies, seasons and episodes
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Display download queue status in various places
+- Display download queue status in various places, including a distinct symbol for blocked imports
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Display download queue status in various places, with a distinct symbol per queue state
+- Display download queue status in various places
+- Show "Downloading" instead of "Missing" on downloading episode rows
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Display download queue status in various places, including a distinct symbol for blocked imports
+- Display download queue status in various places, with a distinct symbol per queue state
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Display download queue status in various places
-- Show "Downloading" instead of "Missing" on downloading episode rows
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS

--- a/Ruddarr/Assets.xcassets/Symbols/ecg.circle.symbolset/Contents.json
+++ b/Ruddarr/Assets.xcassets/Symbols/ecg.circle.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "waveform.path.ecg.circle.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Ruddarr/Assets.xcassets/Symbols/ecg.circle.symbolset/waveform.path.ecg.circle.svg
+++ b/Ruddarr/Assets.xcassets/Symbols/ecg.circle.symbolset/waveform.path.ecg.circle.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 361-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "", point size: 100.0, font version: "22.0d4e4", template writer version: "138.0.0"-->
+ <style>.defaults {-sfsymbols-draw-reverses-motion-groups:true}
+
+.monochrome-0 {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-121a0522636cca72 _enclosure.stroke circle}
+.monochrome-1 {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-121a0522636cca72 -2a12d14de16729e1 waveform.path.ecg}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-121a0522636cca72 _enclosure.stroke circle}
+.multicolor-1:tintColor {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-121a0522636cca72 -2a12d14de16729e1 waveform.path.ecg}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-121a0522636cca72 _enclosure.stroke circle}
+.hierarchical-1:primary {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-121a0522636cca72 -2a12d14de16729e1 waveform.path.ecg}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.7773 0 39.4531-17.627 39.4531-39.4043s-17.6758-39.4043-39.4531-39.4043c-21.7285 0-39.4043 17.627-39.4043 39.4043s17.6758 39.4043 39.4043 39.4043Zm0-7.42188c-17.6758 0-31.9336-14.3066-31.9336-31.9824s14.2578-31.9824 31.9336-31.9824 31.9824 14.3066 31.9824 31.9824-14.3066 31.9824-31.9824 31.9824Zm3.61328-17.7734v-28.4668c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v28.4668c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094Zm-17.8223-10.5957h28.418c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-28.418c-2.24609 0-3.75977 1.51367-3.75977 3.71094 0 2.14844 1.51367 3.61328 3.75977 3.61328Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.4902 0 49.8047-22.3145 49.8047-49.8047s-22.3145-49.8047-49.8047-49.8047-49.8047 22.3145-49.8047 49.8047 22.3145 49.8047 49.8047 49.8047Zm0-8.30078c-22.9492 0-41.5039-18.5547-41.5039-41.5039s18.5547-41.5039 41.5039-41.5039 41.5039 18.5547 41.5039 41.5039-18.5547 41.5039-41.5039 41.5039Zm4.05273-23.0957v-36.9141c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v36.9141c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039Zm-22.5586-14.4043h36.9629c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-36.9629c-2.49023 0-4.15039 1.70898-4.15039 4.15039 0 2.39258 1.66016 4.00391 4.15039 4.00391Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c35.1074 0 63.623-28.4668 63.623-63.5742s-28.5156-63.623-63.623-63.623-63.5742 28.5156-63.5742 63.623 28.4668 63.5742 63.5742 63.5742Zm0-9.08203c-30.127 0-54.4922-24.3652-54.4922-54.4922s24.3652-54.4922 54.4922-54.4922 54.4922 24.3652 54.4922 54.4922-24.3652 54.4922-54.4922 54.4922Zm4.44336-30.3223v-48.4863c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v48.4863c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984Zm-28.7109-19.7754h48.4863c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-48.4863c-2.73438 0-4.58984 1.85547-4.58984 4.58984 0 2.58789 1.85547 4.39453 4.58984 4.39453Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l20.5566-57.5195h0.244141l20.6055 57.5195c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm10.2051-20.9473h30.6641c2.00195 0 3.66211-1.66016 3.66211-3.66211 0-2.05078-1.66016-3.66211-3.66211-3.66211h-30.6641c-2.00195 0-3.66211 1.61133-3.66211 3.66211 0 2.00195 1.66016 3.66211 3.66211 3.66211Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 13.1348 7.86133 7.86133c4.29688 4.39453 9.32617 4.10156 13.8672-1.02539l60.6934-68.2129-4.88281-4.88281-60.2539 67.6758c-1.80664 1.95312-3.4668 2.44141-5.81055 0.0976562l-5.17578-5.12695c-2.29492-2.29492-1.80664-3.95508 0.195312-5.81055l67.4805-62.1582-4.88281-4.83398-68.0664 62.5977c-4.98047 4.58984-5.32227 9.47266-1.02539 13.8184Zm44.873-97.4609c-2.05078 2.00195-2.24609 4.88281-1.07422 6.78711 1.12305 1.80664 3.4668 3.02734 6.5918 2.24609 5.85938-1.66016 12.5977-2.39258 18.8965 0.927734l-2.68555 7.12891c-1.61133 4.00391-0.732422 6.88477 1.70898 9.42383l10.2539 10.3027c2.34375 2.39258 4.54102 2.44141 7.08008 1.95312l4.44336-0.732422 2.58789 2.53906-0.195312 2.24609c-0.0976562 2.29492 0.537109 4.29688 2.7832 6.49414l3.36914 3.32031c2.29492 2.29492 5.51758 2.49023 7.8125 0.195312l12.9883-13.0371c2.29492-2.34375 2.14844-5.37109-0.195312-7.66602l-3.41797-3.41797c-2.19727-2.19727-4.05273-3.02734-6.34766-2.88086l-2.34375 0.244141-2.44141-2.44141 1.02539-4.6875c0.634766-2.73438-0.244141-4.98047-2.88086-7.61719l-11.2793-11.1816c-12.9395-12.8418-35.5957-11.0352-46.6797-0.146484Zm7.08008 2.05078c8.78906-6.39648 25.9766-5.66406 33.6914 1.95312l12.3047 12.207c1.02539 1.02539 1.2207 1.80664 0.927734 3.32031l-1.46484 6.64062 6.73828 6.68945 4.39453-0.244141c1.12305-0.0488281 1.51367 0.0488281 2.34375 0.878906l2.53906 2.49023-10.8398 10.8398-2.49023-2.49023c-0.830078-0.878906-0.976562-1.2207-0.927734-2.39258l0.292969-4.3457-6.68945-6.73828-6.83594 1.17188c-1.41602 0.292969-2.05078 0.195312-3.17383-0.878906l-8.93555-8.88672c-1.07422-1.02539-1.17188-1.70898-0.488281-3.36914l4.58984-11.4746c-6.10352-6.34766-17.041-7.51953-25.5859-4.58984-0.683594 0.244141-0.927734-0.390625-0.390625-0.78125Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.7.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 26 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from </text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2982.23" x2="2982.23" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2884.57" x2="2884.57" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1496.11" x2="1496.11" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1403.58" x2="1403.58" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="603.773" x2="603.773" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="515.649" x2="515.649" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2884.57 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M48.8281 6.73828C72.0215 6.73828 90.8203-12.0605 90.8203-35.2539C90.8203-58.4473 72.0215-77.2461 48.8281-77.2461C25.6348-77.2461 6.83594-58.4473 6.83594-35.2539C6.83594-12.0605 25.6348 6.73828 48.8281 6.73828ZM48.8281-7.42188C33.4473-7.42188 20.9961-19.873 20.9961-35.2539C20.9961-50.6348 33.4473-63.0859 48.8281-63.0859C64.209-63.0859 76.6602-50.6348 76.6602-35.2539C76.6602-19.873 64.209-7.42188 48.8281-7.42188Z" data-clipstroke-keyframes="0 4 0 0.49909934 1.5010297 0 0.24858454 0.2505148 1.749485 0 0.49588796 0.0032113674 1.996659 0 0.7506426 0.7484567 1.251544 0 1 0.49909934 1.5010297"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M29.2619-29.4618L38.6442-29.4618C40.3754-29.4618 41.6182-30.3452 41.9687-31.9592L43.664-39.8918L42.9527-39.8918L47.2902-13.2735C47.8247-9.97416 52.8288-9.97267 53.4807-13.2423L57.4381-32.4921L56.761-32.3659L56.7154-32.228C57.0672-30.4358 58.2476-29.4618 60.0695-29.4618L68.3936-29.4618C70.1814-29.4618 71.6099-30.8576 71.6099-32.6187C71.6099-34.4703 70.2111-35.8349 68.3936-35.8349L61.5753-35.8349L62.2464-35.1473L60.0411-45.2651C59.3268-48.419 54.7341-48.3581 53.8655-45.176L50.1219-28.2383L50.8598-27.6769L46.4303-55.2025C45.8942-58.4425 41.1604-58.5019 40.4774-55.2649L36.1969-35.186L37.128-35.8349L29.2619-35.8349C27.4741-35.8349 26.0457-34.4094 26.0457-32.6187C26.0457-30.8576 27.4741-29.4618 29.2619-29.4618Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1403.58 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M46.2402 4.15039C68.0176 4.15039 85.6934-13.4766 85.6934-35.2539C85.6934-57.0312 68.0176-74.6582 46.2402-74.6582C24.5117-74.6582 6.83594-57.0312 6.83594-35.2539C6.83594-13.4766 24.5117 4.15039 46.2402 4.15039ZM46.2402-3.27148C28.5645-3.27148 14.3066-17.5781 14.3066-35.2539C14.3066-52.9297 28.5645-67.2363 46.2402-67.2363C63.916-67.2363 78.2227-52.9297 78.2227-35.2539C78.2227-17.5781 63.916-3.27148 46.2402-3.27148Z" data-clipstroke-keyframes="0 4 0 0.49914446 1.5008684 0 0.24828511 0.25085935 1.7491465 0 0.49580374 0.0033407123 1.9966576 0 0.75060123 0.7485432 1.2514638 0 1 0.49914446 1.5008684"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M26.7312-30.3667L36.0819-30.3667C37.3997-30.3667 38.262-30.9901 38.5303-32.1783L41.0347-43.8401L40.6465-43.8401L45.6329-13.4927C46.0059-11.168 49.5752-11.1843 50.0436-13.4806L54.7335-36.0679L54.3931-36.0361L55.0608-32.4169C55.3127-31.0587 56.1509-30.3667 57.5374-30.3667L65.7958-30.3667C67.088-30.3667 68.1071-31.3559 68.1071-32.6214C68.1071-33.9555 67.1163-34.9327 65.7958-34.9327L58.3369-34.9327L58.9478-34.4328L56.6096-45.0433C56.1171-47.2963 52.788-47.256 52.2192-44.9583L47.5939-24.1723L48.043-23.9559L43.0042-54.9738C42.6475-57.2418 39.3005-57.2985 38.8201-54.9979L34.4151-34.4659L34.9738-34.9327L26.7312-34.9327C25.439-34.9327 24.4199-33.9152 24.4199-32.6214C24.4199-31.3559 25.439-30.3667 26.7312-30.3667Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 515.649 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M44.0606 1.97072C64.6118 1.97072 81.2886-14.7026 81.2886-35.2539C81.2886-55.8052 64.6118-72.4785 44.0606-72.4785C23.5127-72.4785 6.83594-55.8052 6.83594-35.2539C6.83594-14.7026 23.5127 1.97072 44.0606 1.97072ZM44.0606-0.274438C24.7046-0.274438 9.0391-15.898 9.0391-35.2539C9.0391-54.6099 24.7046-70.2334 44.0606-70.2334C63.4165-70.2334 79.04-54.6099 79.04-35.2539C79.04-15.898 63.4165-0.274438 44.0606-0.274438Z" data-clipstroke-keyframes="0 4 0 0.49911258 1.5011578 0 0.24859153 0.25052106 1.7495481 0 0.49577427 0.0033383023 1.9966562 0 0.75064886 0.74846375 1.2516088 0 1 0.49911258 1.5011578"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M24.7327-31.7154L33.9074-31.7154C34.5841-31.7154 34.9993-32.0367 35.1466-32.6628L38.9396-49.7187L38.7193-49.7187L44.8071-14.2202C44.9746-13.2012 46.4637-13.2114 46.6782-14.2202L52.6085-40.8799L52.3753-40.89L54.2714-32.7437C54.4086-32.057 54.8238-31.7154 55.5207-31.7154L63.3907-31.7154C63.9207-31.7154 64.3533-32.1545 64.3533-32.6578C64.3533-33.1814 63.9308-33.6204 63.3907-33.6204L55.6687-33.6204L55.9641-33.429L53.317-44.5223C53.1025-45.4813 51.7636-45.4712 51.539-44.492L45.6318-18.4281L45.8823-18.4281L39.7845-54.1188C39.6271-55.1175 38.2088-55.1377 37.9943-54.1188L33.3896-33.3893L33.6106-33.6204L24.7327-33.6204C24.2026-33.6204 23.77-33.1713 23.77-32.6578C23.77-32.1545 24.2026-31.7154 24.7327-31.7154Z"/>
+  </g>
+ </g>
+</svg>

--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -2220,6 +2220,16 @@
         }
       }
     },
+    "In Queue" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Queue"
+          }
+        }
+      }
+    },
     "Inactive" : {
       "comment" : "Status of the app subscription",
       "localizations" : {
@@ -2697,7 +2707,7 @@
       }
     },
     "Missing Episodes" : {
-      "comment" : "Series monitoring option",
+      "comment" : "Series monitoring option\nState of media item",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -12,7 +12,7 @@ enum QueueKey: Hashable {
 class Queue {
     static let shared = Queue()
 
-    private var timer: Timer?
+    private var pollingTask: Task<Void, Never>?
 
     var error: API.Error?
 
@@ -29,13 +29,15 @@ class Queue {
     private init() {
         let interval: TimeInterval = isRunningIn(.preview) ? 30 : 5
 
-        self.timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-            Task {
-                await self.fetchTasks()
-            }
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
 
-            Task {
-                if await self.performRefresh {
+                guard let self else { return }
+
+                await self.fetchTasks()
+
+                if self.performRefresh {
                     await self.refreshDownloadClients()
                 }
             }
@@ -48,17 +50,25 @@ class Queue {
         error = nil
         isLoading = true
 
-        for instance in instances {
-            do {
-                items[instance.id] = try await dependencies.api.fetchQueueTasks(instance).records
-            } catch is CancellationError {
-                // do nothing
-            } catch let apiError as API.Error {
-                error = apiError
+        await withThrowingTaskGroup(of: (Instance.ID, [QueueItem]).self) { group in
+            for instance in instances {
+                group.addTask {
+                    (instance.id, try await dependencies.api.fetchQueueTasks(instance).records)
+                }
+            }
 
-                leaveBreadcrumb(.error, category: "queue", message: "Fetch failed", data: ["error": apiError])
-            } catch {
-                self.error = API.Error(from: error)
+            while let result = await group.nextResult() {
+                switch result {
+                case .success(let (instanceId, records)):
+                    items[instanceId] = records
+                case .failure(is CancellationError):
+                    break
+                case .failure(let apiError as API.Error):
+                    error = apiError
+                    // leaveBreadcrumb(.error, category: "queue", message: "Fetch failed", data: ["error": apiError])
+                case .failure(let otherError):
+                    error = API.Error(from: otherError)
+                }
             }
         }
 

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -23,7 +23,7 @@ class Queue {
     var items: [Instance.ID: [QueueItem]] = [:]
     var itemsWithIssues: Int = 0
 
-    let downloading = CurrentValueSubject<Set<QueueKey>, Never>([])
+    let statuses = CurrentValueSubject<[QueueKey: QueueItemStatus], Never>([:])
 
     var active: [QueueItem] {
         items.values.flatMap { $0 }.filter { $0.trackedDownloadState != .imported }
@@ -72,23 +72,34 @@ class Queue {
             itemsWithIssues = uniqueIssues
         }
 
-        let keys = downloadingKeySet()
+        let statuses = activeStatuses()
 
-        if downloading.value != keys {
-            downloading.send(keys)
+        if self.statuses.value != statuses {
+            self.statuses.send(statuses)
         }
 
         isLoading = false
     }
 
-    private func downloadingKeySet() -> Set<QueueKey> {
-        Set(active.flatMap { item -> [QueueKey] in
-            guard let instanceId = item.instanceId else { return [] }
+    private func activeStatuses() -> [QueueKey: QueueItemStatus] {
+        var statuses: [QueueKey: QueueItemStatus] = [:]
+
+        for item in active {
+            guard let instanceId = item.instanceId else { continue }
+
             var keys: [QueueKey] = []
             if let movieId = item.movieId { keys.append(.movie(instanceId: instanceId, id: movieId)) }
             if let seriesId = item.seriesId { keys.append(.series(instanceId: instanceId, id: seriesId)) }
-            return keys
-        })
+
+            let status = item.queueStatus
+
+            // Keep the highest-precedence status when a key has multiple active items
+            for key in keys {
+                statuses[key] = max(statuses[key] ?? status, status)
+            }
+        }
+
+        return statuses
     }
 
     func refreshDownloadClients() async {

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -24,10 +24,7 @@ class Queue {
     var itemsWithIssues: Int = 0
 
     let statuses = CurrentValueSubject<[QueueKey: QueueItemStatus], Never>([:])
-
-    var active: [QueueItem] {
-        items.values.flatMap { $0 }.filter { $0.trackedDownloadState != .imported }
-    }
+    private(set) var active: [QueueItem] = []
 
     private init() {
         let interval: TimeInterval = isRunningIn(.preview) ? 30 : 5
@@ -64,6 +61,9 @@ class Queue {
                 self.error = API.Error(from: error)
             }
         }
+
+        let active = items.values.flatMap { $0 }.filter { $0.trackedDownloadState != .imported }
+        if active != self.active { self.active = active }
 
         let issues = items.flatMap { $0.value }.filter { $0.hasIssue }
         let uniqueIssues = Set(issues.map { $0.taskGroup }).count
@@ -114,20 +114,20 @@ class Queue {
         }
     }
 
-    func isDownloading(_ movie: Movie, instanceId: Instance.ID) -> Bool {
-        active.contains { $0.movieId == movie.id && $0.instanceId == instanceId }
+    func queueStatus(_ movie: Movie, instanceId: Instance.ID) -> QueueItemStatus? {
+        active.highestStatus { $0.movieId == movie.id && $0.instanceId == instanceId }
     }
 
-    func isDownloading(_ series: Series, instanceId: Instance.ID) -> Bool {
-        active.contains { $0.seriesId == series.id && $0.instanceId == instanceId }
+    func queueStatus(_ series: Series, instanceId: Instance.ID) -> QueueItemStatus? {
+        active.highestStatus { $0.seriesId == series.id && $0.instanceId == instanceId }
     }
 
-    func isDownloading(_ episode: Episode, instanceId: Instance.ID) -> Bool {
-        active.contains { $0.episodeId == episode.id && $0.instanceId == instanceId }
+    func queueStatus(_ episode: Episode, instanceId: Instance.ID) -> QueueItemStatus? {
+        active.highestStatus { $0.episodeId == episode.id && $0.instanceId == instanceId }
     }
 
-    func isDownloading(season seasonNumber: Int, of series: Series, instanceId: Instance.ID) -> Bool {
-        active.contains {
+    func queueStatus(season seasonNumber: Int, of series: Series, instanceId: Instance.ID) -> QueueItemStatus? {
+        active.highestStatus {
             $0.seriesId == series.id && $0.seasonNumber == seasonNumber && $0.instanceId == instanceId
         }
     }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct QueueItems: Codable {
     let page: Int
@@ -278,10 +277,10 @@ enum QueueItemStatus: Int, Codable, Comparable {
 
     var label: String {
         switch self {
-        case .downloading, .importPending: String(localized: "Downloading")
-        case .importing: String(localized: "Importing")
-        case .importBlocked: String(localized: "Import Blocked")
-        default: String(localized: "In Queue")
+        case .downloading, .importPending: String(localized: "Downloading", comment: "(Short) State of task in queue")
+        case .importing: String(localized: "Importing", comment: "(Short) State of task in queue")
+        case .importBlocked: String(localized: "Import Blocked", comment: "(Short) State of task in queue")
+        default: String(localized: "In Queue", comment: "(Short) State of task in queue")
         }
     }
 

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct QueueItems: Codable {
     let page: Int
@@ -275,23 +276,26 @@ enum QueueItemStatus: Int, Codable, Comparable {
         lhs.rawValue < rhs.rawValue
     }
 
+    var label: String {
+        switch self {
+        case .downloading, .importPending: String(localized: "Downloading")
+        case .importing: String(localized: "Importing")
+        case .importBlocked: String(localized: "Import Blocked")
+        default: String(localized: "In Queue")
+        }
+    }
+
     var systemImage: String {
         switch self {
-        case .downloading: "arrow.down.circle"
-        case .unknown: "waveform.path.ecg"
-        case .queued: "waveform.path.ecg"
-        case .importPending: "waveform.path.ecg"
-        case .paused: "waveform.path.ecg"
-        case .importing: "waveform.path.ecg"
-        case .warning: "waveform.path.ecg"
-        case .importBlocked: "waveform.path.ecg"
-        case .failed: "waveform.path.ecg"
+        case .downloading, .importPending: "arrow.down.circle"
+        case .importing: "arrow.down.to.line.circle"
+        default: "waveform.path.ecg"
         }
     }
 
     var pulses: Bool {
         switch self {
-        case .downloading, .importing: true
+        case .downloading, .importPending, .importing: true
         default: false
         }
     }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -260,13 +260,7 @@ enum QueueDownloadState: String, Codable {
     case ignored
 }
 
-/// Queue states surfaced as a status symbol across the app.
-///
-/// Cases are declared in ascending precedence: when a movie/series has multiple
-/// active items, the highest-precedence status wins (see `Queue.activeStatuses()`).
-/// Roughly: a state that needs attention (failed, blocked, warning) outranks
-/// active work (downloading, importing), which outranks waiting (queued, pending).
-enum QueueItemStatus: Int, Comparable {
+enum QueueItemStatus: Int, Codable, Comparable {
     case unknown
     case queued
     case importPending
@@ -295,7 +289,6 @@ enum QueueItemStatus: Int, Comparable {
         }
     }
 
-    /// Whether the symbol should pulse, reserved for states with work in flight.
     var pulses: Bool {
         switch self {
         case .downloading, .importing: true
@@ -325,5 +318,11 @@ extension QueueItem {
         case .ignored: .warning
         default: .downloading
         }
+    }
+}
+
+extension Sequence where Element == QueueItem {
+    func highestStatus(where predicate: (QueueItem) -> Bool) -> QueueItemStatus? {
+        filter(predicate).map(\.queueStatus).max()
     }
 }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct QueueItems: Codable {
     let page: Int
@@ -284,18 +285,26 @@ enum QueueItemStatus: Int, Codable, Comparable {
         }
     }
 
-    var systemImage: String {
+    var image: Image {
         switch self {
-        case .downloading, .importPending: "arrow.down.circle"
-        case .importing: "arrow.down.to.line.circle"
-        default: "waveform.path.ecg"
+        case .downloading, .importPending:
+            Image(systemName: "arrow.down.circle")
+        case .importing:
+            Image(systemName: "arrow.down.to.line.circle")
+        case .importBlocked, .failed:
+            Image(systemName: "arrow.down.circle.badge.xmark")
+        case .paused:
+            Image(systemName: "arrow.down.circle.badge.pause")
+        default:
+            Image("ecg.circle") // waveform.path.ecg
         }
     }
 
     var pulses: Bool {
         switch self {
-        case .downloading, .importPending, .importing: true
-        default: false
+        case .queued, .downloading, .importing, .importPending: true
+        case .paused, .failed, .importBlocked: false
+        default: true
         }
     }
 }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -260,20 +260,70 @@ enum QueueDownloadState: String, Codable {
     case ignored
 }
 
-/// The subset of queue states surfaced as a status symbol across the app.
-/// Cases are ordered by precedence: when a movie/series has multiple active
-/// items, the case declared last wins (see `Queue.activeStatuses()`).
+/// Queue states surfaced as a status symbol across the app.
+///
+/// Cases are declared in ascending precedence: when a movie/series has multiple
+/// active items, the highest-precedence status wins (see `Queue.activeStatuses()`).
+/// Roughly: a state that needs attention (failed, blocked, warning) outranks
+/// active work (downloading, importing), which outranks waiting (queued, pending).
 enum QueueItemStatus: Int, Comparable {
+    case unknown
+    case queued
+    case importPending
+    case paused
     case downloading
+    case importing
+    case warning
     case importBlocked
+    case failed
 
     static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.rawValue < rhs.rawValue
+    }
+
+    var systemImage: String {
+        switch self {
+        case .unknown: "questionmark.circle"
+        case .queued: "clock"
+        case .importPending: "tray.and.arrow.down"
+        case .paused: "pause.circle"
+        case .downloading: "arrow.down.circle"
+        case .importing: "square.and.arrow.down"
+        case .warning: "exclamationmark.circle"
+        case .importBlocked: "exclamationmark.triangle"
+        case .failed: "xmark.circle"
+        }
+    }
+
+    /// Whether the symbol should pulse, reserved for states with work in flight.
+    var pulses: Bool {
+        switch self {
+        case .downloading, .importing: true
+        default: false
+        }
     }
 }
 
 extension QueueItem {
     var queueStatus: QueueItemStatus {
-        trackedDownloadState == .importBlocked ? .importBlocked : .downloading
+        if status != "completed" {
+            return switch status {
+            case "downloading": .downloading
+            case "queued", "delay", "downloadClientUnavailable": .queued
+            case "paused": .paused
+            case "warning": .warning
+            case "failed": .failed
+            default: .unknown
+            }
+        }
+
+        return switch trackedDownloadState {
+        case .importing: .importing
+        case .importPending: .importPending
+        case .importBlocked: .importBlocked
+        case .failedPending, .failed: .failed
+        case .ignored: .warning
+        default: .downloading
+        }
     }
 }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -259,3 +259,21 @@ enum QueueDownloadState: String, Codable {
     case failed
     case ignored
 }
+
+/// The subset of queue states surfaced as a status symbol across the app.
+/// Cases are ordered by precedence: when a movie/series has multiple active
+/// items, the case declared last wins (see `Queue.activeStatuses()`).
+enum QueueItemStatus: Int, Comparable {
+    case downloading
+    case importBlocked
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+extension QueueItem {
+    var queueStatus: QueueItemStatus {
+        trackedDownloadState == .importBlocked ? .importBlocked : .downloading
+    }
+}

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -283,15 +283,15 @@ enum QueueItemStatus: Int, Comparable {
 
     var systemImage: String {
         switch self {
-        case .unknown: "questionmark.circle"
-        case .queued: "clock"
-        case .importPending: "tray.and.arrow.down"
-        case .paused: "pause.circle"
         case .downloading: "arrow.down.circle"
-        case .importing: "square.and.arrow.down"
-        case .warning: "exclamationmark.circle"
-        case .importBlocked: "exclamationmark.triangle"
-        case .failed: "xmark.circle"
+        case .unknown: "waveform.path.ecg"
+        case .queued: "waveform.path.ecg"
+        case .importPending: "waveform.path.ecg"
+        case .paused: "waveform.path.ecg"
+        case .importing: "waveform.path.ecg"
+        case .warning: "waveform.path.ecg"
+        case .importBlocked: "waveform.path.ecg"
+        case .failed: "waveform.path.ecg"
         }
     }
 

--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -37,7 +37,7 @@ struct Episode: Identifiable, Codable, Equatable {
     var series: Series?
 
     var calendarGroupCount: Int?
-    var isDownloadingInCalendar: Bool?
+    var queueStatusInCalendar: QueueItemStatus?
 
     var calendarGroup: String {
         "\(seriesId):\(seasonNumber):\(airDateUtc?.formatted(.iso8601) ?? "")"

--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -65,7 +65,7 @@ struct Episode: Identifiable, Codable, Equatable {
         String(format: "%dx%02d", seasonNumber, episodeNumber)
     }
 
-    var statusLabel: String {
+    var stateLabel: String {
         if hasFile {
             return String(localized: "Downloaded", comment: "(Single word) Episode status label")
         }

--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -67,14 +67,14 @@ struct Episode: Identifiable, Codable, Equatable {
 
     var stateLabel: String {
         if hasFile {
-            return String(localized: "Downloaded", comment: "(Single word) Episode status label")
+            return String(localized: "Downloaded", comment: "(Single word) Episode state label")
         }
 
         if !hasAired {
-            return String(localized: "Unaired", comment: "(Single word) Episode status label")
+            return String(localized: "Unaired", comment: "(Single word) Episode state label")
         }
 
-        return String(localized: "Missing", comment: "(Single word) Episode status label")
+        return String(localized: "Missing", comment: "(Single word) Episode state label")
     }
 
     var runtimeLabel: String? {

--- a/Ruddarr/Models/Series/Series.swift
+++ b/Ruddarr/Models/Series/Series.swift
@@ -160,20 +160,22 @@ struct Series: Media, Identifiable, Equatable, Codable {
             .formattedList()
     }
 
-    var stateLabel: LocalizedStringKey {
+    var stateLabel: String {
         if isDownloaded {
-            return "Downloaded"
+            return String(localized: "Downloaded", comment: "State of media item")
         }
 
         if isWaiting {
-            return "Unreleased"
+            return String(localized: "Unreleased", comment: "State of media item")
         }
 
         if monitored && percentOfEpisodes < 100 {
-            return episodeFileCount == 0 ? "Missing" : "Missing Episodes"
+            return episodeFileCount == 0
+                ? String(localized: "Missing", comment: "State of media item")
+                : String(localized: "Missing Episodes", comment: "State of media item")
         }
 
-        return "Unwanted"
+        return String(localized: "Unwanted", comment: "State of media item")
     }
 
     var yearLabel: String {

--- a/Ruddarr/Utilities/View.swift
+++ b/Ruddarr/Utilities/View.swift
@@ -26,10 +26,10 @@ extension View {
     }
 
     @MainActor
-    func tracksDownloading(_ key: QueueKey?, into isDownloading: Binding<Bool>) -> some View {
-        onReceive(Queue.shared.downloading) { keys in
-            let value = key.map(keys.contains) ?? false
-            if value != isDownloading.wrappedValue { isDownloading.wrappedValue = value }
+    func tracksQueueStatus(_ key: QueueKey?, into status: Binding<QueueItemStatus?>) -> some View {
+        onReceive(Queue.shared.statuses) { statuses in
+            let value = key.flatMap { statuses[$0] }
+            if value != status.wrappedValue { status.wrappedValue = value }
         }
     }
 

--- a/Ruddarr/Views/Calendar/CalendarMedia.swift
+++ b/Ruddarr/Views/Calendar/CalendarMedia.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CalendarMovie: View {
     var date: Date
     var movie: Movie
-    var isDownloading: Bool
+    var status: QueueItemStatus?
     var open: (CalendarSelection) -> Void
 
     @EnvironmentObject var settings: AppSettings
@@ -49,8 +49,8 @@ struct CalendarMovie: View {
 
     @ViewBuilder
     var statusIcon: some View {
-        if isDownloading {
-            Downloading()
+        if let status {
+            QueueStatusIcon(status: status)
         } else if movie.isDownloaded {
             Image(systemName: "checkmark").symbolVariant(.circle.fill)
         } else if !movie.monitored {
@@ -65,7 +65,7 @@ struct CalendarMovie: View {
 
 struct CalendarEpisode: View {
     var episode: Episode
-    var isDownloading: Bool
+    var status: QueueItemStatus?
     var open: (CalendarSelection) -> Void
 
     @EnvironmentObject var settings: AppSettings
@@ -145,8 +145,8 @@ struct CalendarEpisode: View {
 
     @ViewBuilder
     var statusIcon: some View {
-        if isDownloading {
-            Downloading()
+        if let status {
+            QueueStatusIcon(status: status)
         } else if episode.isDownloaded {
             Image(systemName: "checkmark").symbolVariant(.circle.fill)
         } else if !episode.monitored || episode.series?.monitored == false {

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -189,9 +189,9 @@ struct CalendarView: View {
             let episodes = grouped.values.compactMap { group -> Episode? in
                 guard var episode = group.first else { return nil }
                 episode.calendarGroupCount = group.count
-                episode.isDownloadingInCalendar = group.contains {
-                    isDownloading(\.episodeId, $0.id, $0.instanceId, in: active)
-                }
+                episode.queueStatusInCalendar = group
+                    .compactMap { queueStatus(\.episodeId, $0.id, $0.instanceId, in: active) }
+                    .max()
                 return episode
             }
 
@@ -200,9 +200,9 @@ struct CalendarView: View {
         }
     }
 
-    func isDownloading(_ idKey: KeyPath<QueueItem, Int?>, _ id: Int, _ instanceId: Instance.ID?, in items: [QueueItem]) -> Bool {
-        guard let instanceId else { return false }
-        return items.contains { $0[keyPath: idKey] == id && $0.instanceId == instanceId }
+    func queueStatus(_ idKey: KeyPath<QueueItem, Int?>, _ id: Int, _ instanceId: Instance.ID?, in items: [QueueItem]) -> QueueItemStatus? {
+        guard let instanceId else { return nil }
+        return items.highestStatus { $0[keyPath: idKey] == id && $0.instanceId == instanceId }
     }
 
     func includeEpisodeInCalendar(_ episode: Episode) -> Bool {
@@ -286,7 +286,7 @@ struct CalendarView: View {
                     CalendarMovie(
                         date: date,
                         movie: movie,
-                        isDownloading: isDownloading(\.movieId, movie.id, movie.instanceId, in: active),
+                        status: queueStatus(\.movieId, movie.id, movie.instanceId, in: active),
                         open: open
                     )
                 }
@@ -296,7 +296,7 @@ struct CalendarView: View {
                 ForEach(episodes) { episode in
                     CalendarEpisode(
                         episode: episode,
-                        isDownloading: episode.isDownloadingInCalendar ?? false,
+                        status: episode.queueStatusInCalendar,
                         open: open
                     )
                 }

--- a/Ruddarr/Views/Movies/MovieDetails+Overview.swift
+++ b/Ruddarr/Views/Movies/MovieDetails+Overview.swift
@@ -49,19 +49,19 @@ extension MovieDetails {
             .font(.caption)
             .fontWeight(.semibold)
             .textCase(.uppercase)
-            .shimmering(active: isDownloading, color: settings.theme.tint)
+            .shimmering(active: queueStatus != nil, color: settings.theme.tint)
     }
 
     var stateLabel: String {
-        if isDownloading {
+        if queueStatus != nil {
             return String(localized: "Downloading")
         }
 
         return movie.stateLabel
     }
 
-    var isDownloading: Bool {
-        queue.isDownloading(movie, instanceId: instance.id)
+    var queueStatus: QueueItemStatus? {
+        queue.queueStatus(movie, instanceId: instance.id)
     }
 
     var detailsTitle: some View {

--- a/Ruddarr/Views/Movies/MovieDetails+Overview.swift
+++ b/Ruddarr/Views/Movies/MovieDetails+Overview.swift
@@ -53,10 +53,7 @@ extension MovieDetails {
     }
 
     var stateLabel: String {
-        if queueStatus != nil {
-            return String(localized: "Downloading")
-        }
-
+        if let label = queueStatus?.label { return label }
         return movie.stateLabel
     }
 

--- a/Ruddarr/Views/Movies/MovieGridCard.swift
+++ b/Ruddarr/Views/Movies/MovieGridCard.swift
@@ -6,7 +6,7 @@ struct MovieGridCard: View {
     @Environment(\.deviceType) private var deviceType
     @Environment(RadarrInstance.self) private var instance
 
-    @State private var isDownloading = false
+    @State private var queueStatus: QueueItemStatus?
 
     var body: some View {
         HStack(alignment: .top, spacing: deviceType == .phone ? 10 : 14) {
@@ -64,7 +64,7 @@ struct MovieGridCard: View {
         } preview: {
             poster.frame(width: 300, height: 450)
         }
-        .tracksDownloading(movie.queueKey, into: $isDownloading)
+        .tracksQueueStatus(movie.queueKey, into: $queueStatus)
     }
 
     var poster: some View {
@@ -88,8 +88,8 @@ struct MovieGridCard: View {
                 .imageScale(iconScale)
 
             Group {
-                if isDownloading {
-                    Downloading()
+                if let queueStatus {
+                    QueueStatusIcon(status: queueStatus)
                 } else if movie.isDownloaded {
                     Image(systemName: "checkmark").symbolVariant(.circle.fill)
                 } else if movie.isWaiting {

--- a/Ruddarr/Views/Movies/MovieGridPoster.swift
+++ b/Ruddarr/Views/Movies/MovieGridPoster.swift
@@ -33,13 +33,13 @@ struct MovieGridPoster: View {
 struct MoviePosterOverlay: View {
     var movie: Movie
 
-    @State private var isDownloading = false
+    @State private var queueStatus: QueueItemStatus?
 
     var body: some View {
         MediaGridPosterOverlay {
             Group {
-                if isDownloading {
-                    Downloading(color: .white)
+                if let queueStatus {
+                    QueueStatusIcon(status: queueStatus, color: .white)
                 } else if movie.isDownloaded {
                     Image(systemName: "checkmark").symbolVariant(.circle.fill)
                 } else if movie.isWaiting {
@@ -58,7 +58,7 @@ struct MoviePosterOverlay: View {
                 .foregroundStyle(.white)
                 .imageScale(.gridItem)
         }
-        .tracksDownloading(movie.queueKey, into: $isDownloading)
+        .tracksQueueStatus(movie.queueKey, into: $queueStatus)
     }
 }
 

--- a/Ruddarr/Views/Series/EpisodeView.swift
+++ b/Ruddarr/Views/Series/EpisodeView.swift
@@ -117,11 +117,8 @@ struct EpisodeView: View {
     }
 
     var stateLabel: String {
-        if queueStatus != nil {
-            return String(localized: "Downloading")
-        }
-
-        return episode.statusLabel
+        if let label = queueStatus?.label { return label }
+        return episode.stateLabel
     }
 
     var queueStatus: QueueItemStatus? {

--- a/Ruddarr/Views/Series/EpisodeView.swift
+++ b/Ruddarr/Views/Series/EpisodeView.swift
@@ -113,19 +113,19 @@ struct EpisodeView: View {
             .font(.caption)
             .fontWeight(.semibold)
             .textCase(.uppercase)
-            .shimmering(active: isDownloading, color: settings.theme.tint)
+            .shimmering(active: queueStatus != nil, color: settings.theme.tint)
     }
 
     var stateLabel: String {
-        if isDownloading {
+        if queueStatus != nil {
             return String(localized: "Downloading")
         }
 
         return episode.statusLabel
     }
 
-    var isDownloading: Bool {
-        queue.isDownloading(episode, instanceId: instance.id)
+    var queueStatus: QueueItemStatus? {
+        queue.queueStatus(episode, instanceId: instance.id)
     }
 
     var details: some View {

--- a/Ruddarr/Views/Series/SeasonCard.swift
+++ b/Ruddarr/Views/Series/SeasonCard.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SeasonCard: View {
     @Binding var series: Series
     var season: Season
-    var isDownloading: Bool = false
+    var status: QueueItemStatus?
 
     @State private var isWorking: Bool = false
 
@@ -25,8 +25,8 @@ struct SeasonCard: View {
 
                 Spacer()
 
-                if isDownloading {
-                    Downloading(color: colorScheme == .dark ? .lightGray : .darkGray)
+                if let status {
+                    QueueStatusIcon(status: status, color: colorScheme == .dark ? .lightGray : .darkGray)
                 }
 
                 Button {

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct EpisodeRow: View {
     var episode: Episode
-    var isDownloading: Bool = false
+    var status: QueueItemStatus?
 
     @EnvironmentObject var settings: AppSettings
     @Environment(SonarrInstance.self) var instance
@@ -30,7 +30,7 @@ struct EpisodeRow: View {
                     if let file = episodeFile {
                         Text(file.quality.quality.normalizedName)
                             .foregroundStyle(.secondary)
-                    } else if isDownloading {
+                    } else if status != nil {
                         Text("Downloading")
                             .foregroundStyle(.secondary)
                     } else {
@@ -53,8 +53,8 @@ struct EpisodeRow: View {
 
             Spacer()
 
-            if isDownloading {
-                Downloading(color: colorScheme == .dark ? .lightGray : .darkGray)
+            if let status {
+                QueueStatusIcon(status: status, color: colorScheme == .dark ? .lightGray : .darkGray)
             }
 
             monitorButton

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -30,11 +30,11 @@ struct EpisodeRow: View {
                     if let file = episodeFile {
                         Text(file.quality.quality.normalizedName)
                             .foregroundStyle(.secondary)
-                    } else if status != nil {
-                        Text("Downloading")
+                    } else if let status {
+                        Text(status.label)
                             .foregroundStyle(.secondary)
                     } else {
-                        Text(episode.statusLabel)
+                        Text(episode.stateLabel)
                             .foregroundStyle(episodeIsMissing ? .red : .secondary)
                     }
 

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -30,6 +30,9 @@ struct EpisodeRow: View {
                     if let file = episodeFile {
                         Text(file.quality.quality.normalizedName)
                             .foregroundStyle(.secondary)
+                    } else if isDownloading {
+                        Text("Downloading")
+                            .foregroundStyle(.secondary)
                     } else {
                         Text(episode.statusLabel)
                             .foregroundStyle(episodeIsMissing ? .red : .secondary)

--- a/Ruddarr/Views/Series/SeasonView.swift
+++ b/Ruddarr/Views/Series/SeasonView.swift
@@ -193,7 +193,7 @@ struct SeasonView: View {
                         NavigationLink(
                             value: SeriesPath.episode(episode.seriesId, episode.id)
                         ) {
-                            EpisodeRow(episode: episode, isDownloading: queue.isDownloading(episode, instanceId: instance.id))
+                            EpisodeRow(episode: episode, status: queue.queueStatus(episode, instanceId: instance.id))
                                 .environment(instance)
                                 .environmentObject(settings)
                         }

--- a/Ruddarr/Views/Series/SeriesDetails+Overview.swift
+++ b/Ruddarr/Views/Series/SeriesDetails+Overview.swift
@@ -50,19 +50,19 @@ extension SeriesDetails {
             .font(.caption)
             .fontWeight(.semibold)
             .textCase(.uppercase)
-            .shimmering(active: isDownloading, color: settings.theme.tint)
+            .shimmering(active: queueStatus != nil, color: settings.theme.tint)
     }
 
     var stateLabel: LocalizedStringKey {
-        if isDownloading {
+        if queueStatus != nil {
             return "Downloading"
         }
 
         return series.stateLabel
     }
 
-    var isDownloading: Bool {
-        queue.isDownloading(series, instanceId: instance.id)
+    var queueStatus: QueueItemStatus? {
+        queue.queueStatus(series, instanceId: instance.id)
     }
 
     var detailsTitle: some View {

--- a/Ruddarr/Views/Series/SeriesDetails+Overview.swift
+++ b/Ruddarr/Views/Series/SeriesDetails+Overview.swift
@@ -53,11 +53,8 @@ extension SeriesDetails {
             .shimmering(active: queueStatus != nil, color: settings.theme.tint)
     }
 
-    var stateLabel: LocalizedStringKey {
-        if queueStatus != nil {
-            return "Downloading"
-        }
-
+    var stateLabel: String {
+        if let label = queueStatus?.label { return label }
         return series.stateLabel
     }
 

--- a/Ruddarr/Views/Series/SeriesDetails.swift
+++ b/Ruddarr/Views/Series/SeriesDetails.swift
@@ -161,7 +161,7 @@ struct SeriesDetails: View {
                         SeasonCard(
                             series: $series,
                             season: season,
-                            isDownloading: queue.isDownloading(season: season.seasonNumber, of: series, instanceId: instance.id)
+                            status: queue.queueStatus(season: season.seasonNumber, of: series, instanceId: instance.id)
                         )
                     }.buttonStyle(.plain)
                 }

--- a/Ruddarr/Views/Series/SeriesGridCard.swift
+++ b/Ruddarr/Views/Series/SeriesGridCard.swift
@@ -7,7 +7,7 @@ struct SeriesGridCard: View {
     @Environment(\.deviceType) private var deviceType
     @Environment(SonarrInstance.self) private var instance
 
-    @State private var isDownloading = false
+    @State private var queueStatus: QueueItemStatus?
 
     init(series: Series, model: Series? = nil) {
         self.series = series
@@ -64,7 +64,7 @@ struct SeriesGridCard: View {
         } preview: {
             poster.frame(width: 300, height: 450)
         }
-        .tracksDownloading(series.queueKey, into: $isDownloading)
+        .tracksQueueStatus(series.queueKey, into: $queueStatus)
     }
 
     var poster: some View {
@@ -88,8 +88,8 @@ struct SeriesGridCard: View {
                 .imageScale(iconScale)
 
             Group {
-                if isDownloading {
-                    Downloading()
+                if let queueStatus {
+                    QueueStatusIcon(status: queueStatus)
                 } else if series.isDownloaded {
                     Image(systemName: "checkmark").symbolVariant(.circle.fill)
                 } else if series.isWaiting {

--- a/Ruddarr/Views/Series/SeriesGridPoster.swift
+++ b/Ruddarr/Views/Series/SeriesGridPoster.swift
@@ -54,13 +54,13 @@ struct SeriesGridPoster: View {
 struct SeriesPosterOverlay: View {
     var series: Series
 
-    @State private var isDownloading = false
+    @State private var queueStatus: QueueItemStatus?
 
     var body: some View {
         MediaGridPosterOverlay {
             Group {
-                if isDownloading {
-                    Downloading(color: .white)
+                if let queueStatus {
+                    QueueStatusIcon(status: queueStatus, color: .white)
                 } else if series.isDownloaded {
                     Image(systemName: "checkmark").symbolVariant(.circle.fill)
                 } else if series.isWaiting {
@@ -83,7 +83,7 @@ struct SeriesPosterOverlay: View {
                 .foregroundStyle(.white)
                 .imageScale(.gridItem)
         }
-        .tracksDownloading(series.queueKey, into: $isDownloading)
+        .tracksQueueStatus(series.queueKey, into: $queueStatus)
     }
 }
 

--- a/Ruddarr/Views/Shared/Loading.swift
+++ b/Ruddarr/Views/Shared/Loading.swift
@@ -14,13 +14,13 @@ struct QueueStatusIcon: View {
     @EnvironmentObject var settings: AppSettings
 
     var body: some View {
-        let icon = Image(systemName: status.systemImage)
+        let icon = status.image
             .symbolRenderingMode(.palette)
             .foregroundStyle(settings.theme.tint, color)
             .accessibilityLabel(status.label)
 
         if status.pulses {
-            icon.symbolEffect(.pulse.byLayer, options: .repeat(.periodic(delay: 0.5)))
+            icon.symbolEffect(.pulse.byLayer, options: .repeat(.periodic(delay: 0.2)))
         } else {
             icon
         }

--- a/Ruddarr/Views/Shared/Loading.swift
+++ b/Ruddarr/Views/Shared/Loading.swift
@@ -8,39 +8,34 @@ struct Loading: View {
     }
 }
 
-/// Renders the symbol for a tracked queue status (see `View.tracksQueueStatus`).
+/// Renders the symbol for a queue status (see `View.tracksQueueStatus`).
+/// The symbol and whether it pulses are driven by `QueueItemStatus`, so any
+/// state — including ones without a bespoke treatment — resolves to a symbol.
 struct QueueStatusIcon: View {
     var status: QueueItemStatus
     var color: Color = .secondary
 
+    @EnvironmentObject var settings: AppSettings
+
     var body: some View {
-        switch status {
-        case .downloading: Downloading(color: color)
-        case .importBlocked: ImportBlocked(color: color)
+        let icon = Image(systemName: status.systemImage)
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(settings.theme.tint, color)
+
+        if status.pulses {
+            icon.symbolEffect(.pulse.byLayer, options: .repeat(.periodic(delay: 0.5)))
+        } else {
+            icon
         }
     }
 }
 
+/// Standalone downloading indicator for item-level views not driven by `Queue.statuses`.
 struct Downloading: View {
     var color: Color = .secondary
-    @EnvironmentObject var settings: AppSettings
 
     var body: some View {
-        Image(systemName: "arrow.down.circle")
-            .symbolEffect(.pulse.byLayer, options: .repeat(.periodic(delay: 0.5)))
-            .symbolRenderingMode(.palette)
-            .foregroundStyle(settings.theme.tint, color)
-    }
-}
-
-struct ImportBlocked: View {
-    var color: Color = .secondary
-    @EnvironmentObject var settings: AppSettings
-
-    var body: some View {
-        Image(systemName: "exclamationmark.triangle")
-            .symbolRenderingMode(.palette)
-            .foregroundStyle(settings.theme.tint, color)
+        QueueStatusIcon(status: .downloading, color: color)
     }
 }
 
@@ -49,11 +44,19 @@ struct ImportBlocked: View {
 }
 
 #Preview("Queue Status") {
-    HStack {
-        QueueStatusIcon(status: .downloading)
-        QueueStatusIcon(status: .downloading, color: .lightGray)
-        QueueStatusIcon(status: .importBlocked)
-        QueueStatusIcon(status: .importBlocked, color: .lightGray)
+    let statuses: [QueueItemStatus] = [
+        .downloading, .importing, .queued, .importPending,
+        .paused, .warning, .importBlocked, .failed, .unknown,
+    ]
+
+    VStack(spacing: 16) {
+        ForEach(statuses, id: \.self) { status in
+            HStack(spacing: 16) {
+                QueueStatusIcon(status: status)
+                QueueStatusIcon(status: status, color: .lightGray)
+            }
+        }
     }
+    .imageScale(.large)
     .withAppState()
 }

--- a/Ruddarr/Views/Shared/Loading.swift
+++ b/Ruddarr/Views/Shared/Loading.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 struct Loading: View {
@@ -8,9 +7,6 @@ struct Loading: View {
     }
 }
 
-/// Renders the symbol for a queue status (see `View.tracksQueueStatus`).
-/// The symbol and whether it pulses are driven by `QueueItemStatus`, so any
-/// state — including ones without a bespoke treatment — resolves to a symbol.
 struct QueueStatusIcon: View {
     var status: QueueItemStatus
     var color: Color = .secondary
@@ -27,15 +23,6 @@ struct QueueStatusIcon: View {
         } else {
             icon
         }
-    }
-}
-
-/// Standalone downloading indicator for item-level views not driven by `Queue.statuses`.
-struct Downloading: View {
-    var color: Color = .secondary
-
-    var body: some View {
-        QueueStatusIcon(status: .downloading, color: color)
     }
 }
 

--- a/Ruddarr/Views/Shared/Loading.swift
+++ b/Ruddarr/Views/Shared/Loading.swift
@@ -8,6 +8,19 @@ struct Loading: View {
     }
 }
 
+/// Renders the symbol for a tracked queue status (see `View.tracksQueueStatus`).
+struct QueueStatusIcon: View {
+    var status: QueueItemStatus
+    var color: Color = .secondary
+
+    var body: some View {
+        switch status {
+        case .downloading: Downloading(color: color)
+        case .importBlocked: ImportBlocked(color: color)
+        }
+    }
+}
+
 struct Downloading: View {
     var color: Color = .secondary
     @EnvironmentObject var settings: AppSettings
@@ -20,15 +33,27 @@ struct Downloading: View {
     }
 }
 
+struct ImportBlocked: View {
+    var color: Color = .secondary
+    @EnvironmentObject var settings: AppSettings
+
+    var body: some View {
+        Image(systemName: "exclamationmark.triangle")
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(settings.theme.tint, color)
+    }
+}
+
 #Preview {
     Loading()
 }
 
-#Preview("Downloading") {
+#Preview("Queue Status") {
     HStack {
-        Downloading()
-        Downloading(color: .lightGray)
-        Downloading(color: .red)
+        QueueStatusIcon(status: .downloading)
+        QueueStatusIcon(status: .downloading, color: .lightGray)
+        QueueStatusIcon(status: .importBlocked)
+        QueueStatusIcon(status: .importBlocked, color: .lightGray)
     }
     .withAppState()
 }

--- a/Ruddarr/Views/Shared/Loading.swift
+++ b/Ruddarr/Views/Shared/Loading.swift
@@ -17,6 +17,7 @@ struct QueueStatusIcon: View {
         let icon = Image(systemName: status.systemImage)
             .symbolRenderingMode(.palette)
             .foregroundStyle(settings.theme.tint, color)
+            .accessibilityLabel(status.label)
 
         if status.pulses {
             icon.symbolEffect(.pulse.byLayer, options: .repeat(.periodic(delay: 0.5)))

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,5 +1,5 @@
 ### Added
-- Display download queue status in various places
+- Display queue status for movies, seasons and episodes
 - Switched to sheets for calendar navigation
 - Added quick look preview to media posters
 - Added "History" to sidebar on iPadOS


### PR DESCRIPTION
## Summary

Extends the existing per-key queue tracking so states beyond "downloading" render their own symbol — starting with **import blocked**, which now shows a distinct warning icon instead of the download arrow. This reuses the single existing event handler rather than adding new subscriptions.

## How it works

The tracking channel previously carried a `Set<QueueKey>` (downloading: yes/no). It now carries a status per key (`[QueueKey: QueueItemStatus]`), so any number of queue states can map to distinct symbols through the **same** Combine subject and the **same** `onReceive` — no extra event handlers.

- **`QueueItem`** — new `QueueItemStatus` enum (`Comparable`, ordered by precedence) and a `queueStatus` property mapping `trackedDownloadState == .importBlocked` → `.importBlocked`, all other active items → `.downloading`.
- **`Queue`** — `downloading` subject replaced with `statuses`; the key-set builder became `activeStatuses()`, merging multiple active items per movie/series and keeping the highest-precedence status (a blocked import wins over a sibling still downloading).
- **`View.tracksDownloading(into: Binding<Bool>)`** → **`tracksQueueStatus(into: Binding<QueueItemStatus?>)`** — same lone subscription, now a dictionary lookup.
- **`QueueStatusIcon`** — central view that switches a status to the right symbol; `ImportBlocked` (`exclamationmark.triangle`) added alongside the existing `Downloading` arrow.
- Updated the four consumers (Movie/Series grid card + poster) to bind an optional status instead of a `Bool`.

## Notes

- The blocked-import symbol is `exclamationmark.triangle` (no pulse animation, unlike the downloading arrow). Easy to swap if a different glyph is preferred.
- Could not compile in this environment (no Swift/Xcode toolchain); logic was reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsBDsDojBV282MJvk2C9Fg)_