### PR TITLE
Navigate out of search results after grabbing release in calendar sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sidebar colors on macOS 27
 - Fixed blurry discovery headline on iPadOS
 - Fixed toasts not displaying above some sheets
-- Fixed staying on the interactive search results after grabbing a release from the calendar sheet
 
 ## 1.8.3 - 2026-06-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sidebar colors on macOS 27
 - Fixed blurry discovery headline on iPadOS
 - Fixed toasts not displaying above some sheets
+- Fixed staying on the interactive search results after grabbing a release from the calendar sheet
 
 ## 1.8.3 - 2026-06-23
 ### Added

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -95,13 +95,7 @@ private struct CalendarMovieSheet: View {
                 }
         }
         .environment(instance)
-        .inCalendarSheet {
-            dismiss()
-        } pop: {
-            if !path.isEmpty {
-                path.removeLast()
-            }
-        }
+        .inCalendarSheet(dismiss: { dismiss() }, path: $path)
         .displayToasts()
     }
 }
@@ -152,13 +146,7 @@ private struct CalendarEpisodeSheet: View {
                 }
         }
         .environment(instance)
-        .inCalendarSheet {
-            dismiss()
-        } pop: {
-            if !path.isEmpty {
-                path.removeLast()
-            }
-        }
+        .inCalendarSheet(dismiss: { dismiss() }, path: $path)
         .displayToasts()
     }
 }

--- a/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
+++ b/Ruddarr/Views/Calendar/CalendarDetailSheet.swift
@@ -97,6 +97,10 @@ private struct CalendarMovieSheet: View {
         .environment(instance)
         .inCalendarSheet {
             dismiss()
+        } pop: {
+            if !path.isEmpty {
+                path.removeLast()
+            }
         }
         .displayToasts()
     }
@@ -150,6 +154,10 @@ private struct CalendarEpisodeSheet: View {
         .environment(instance)
         .inCalendarSheet {
             dismiss()
+        } pop: {
+            if !path.isEmpty {
+                path.removeLast()
+            }
         }
         .displayToasts()
     }

--- a/Ruddarr/Views/Calendar/CalendarSheetContext.swift
+++ b/Ruddarr/Views/Calendar/CalendarSheetContext.swift
@@ -29,7 +29,14 @@ enum CalendarSelection: Identifiable {
 
 struct CalendarSheetContext {
     let dismiss: @MainActor () -> Void
-    let pop: @MainActor () -> Void
+    let path: Binding<NavigationPath>
+
+    @MainActor
+    func pop() {
+        if !path.wrappedValue.isEmpty {
+            path.wrappedValue.removeLast()
+        }
+    }
 }
 
 private struct CalendarSheetContextKey: EnvironmentKey {
@@ -46,8 +53,8 @@ extension EnvironmentValues {
 extension View {
     func inCalendarSheet(
         dismiss: @escaping @MainActor () -> Void,
-        pop: @escaping @MainActor () -> Void
+        path: Binding<NavigationPath>
     ) -> some View {
-        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss, pop: pop))
+        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss, path: path))
     }
 }

--- a/Ruddarr/Views/Calendar/CalendarSheetContext.swift
+++ b/Ruddarr/Views/Calendar/CalendarSheetContext.swift
@@ -29,14 +29,7 @@ enum CalendarSelection: Identifiable {
 
 struct CalendarSheetContext {
     let dismiss: @MainActor () -> Void
-    let path: Binding<NavigationPath>
-
-    @MainActor
-    func pop() {
-        if !path.wrappedValue.isEmpty {
-            path.wrappedValue.removeLast()
-        }
-    }
+    let pop: @MainActor () -> Void
 }
 
 private struct CalendarSheetContextKey: EnvironmentKey {
@@ -55,6 +48,13 @@ extension View {
         dismiss: @escaping @MainActor () -> Void,
         path: Binding<NavigationPath>
     ) -> some View {
-        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss, path: path))
+        environment(\.inCalendarSheet, CalendarSheetContext(
+            dismiss: dismiss,
+            pop: {
+                if !path.wrappedValue.isEmpty {
+                    path.wrappedValue.removeLast()
+                }
+            }
+        ))
     }
 }

--- a/Ruddarr/Views/Calendar/CalendarSheetContext.swift
+++ b/Ruddarr/Views/Calendar/CalendarSheetContext.swift
@@ -29,6 +29,7 @@ enum CalendarSelection: Identifiable {
 
 struct CalendarSheetContext {
     let dismiss: @MainActor () -> Void
+    let pop: @MainActor () -> Void
 }
 
 private struct CalendarSheetContextKey: EnvironmentKey {
@@ -43,7 +44,10 @@ extension EnvironmentValues {
 }
 
 extension View {
-    func inCalendarSheet(dismiss: @escaping @MainActor () -> Void) -> some View {
-        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss))
+    func inCalendarSheet(
+        dismiss: @escaping @MainActor () -> Void,
+        pop: @escaping @MainActor () -> Void
+    ) -> some View {
+        environment(\.inCalendarSheet, CalendarSheetContext(dismiss: dismiss, pop: pop))
     }
 }

--- a/Ruddarr/Views/Movies/Releases/MovieReleaseSheet.swift
+++ b/Ruddarr/Views/Movies/Releases/MovieReleaseSheet.swift
@@ -11,6 +11,7 @@ struct MovieReleaseSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.deviceType) private var deviceType
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.inCalendarSheet) private var inCalendarSheet
 
     @State private var showGrabConfirmation: Bool = false
 
@@ -265,7 +266,9 @@ struct MovieReleaseSheet: View {
 
         dismiss()
 
-        if !dependencies.router.moviesPath.isEmpty {
+        if let inCalendarSheet {
+            inCalendarSheet.pop()
+        } else if !dependencies.router.moviesPath.isEmpty {
             dependencies.router.moviesPath.removeLast()
         }
 

--- a/Ruddarr/Views/Series/Releases/SeriesReleaseSheet.swift
+++ b/Ruddarr/Views/Series/Releases/SeriesReleaseSheet.swift
@@ -13,6 +13,7 @@ struct SeriesReleaseSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.deviceType) private var deviceType
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.inCalendarSheet) private var inCalendarSheet
 
     @State private var showGrabConfirmation: Bool = false
 
@@ -284,7 +285,9 @@ struct SeriesReleaseSheet: View {
 
         dismiss()
 
-        if !dependencies.router.seriesPath.isEmpty {
+        if let inCalendarSheet {
+            inCalendarSheet.pop()
+        } else if !dependencies.router.seriesPath.isEmpty {
             dependencies.router.seriesPath.removeLast()
         }
 


### PR DESCRIPTION
When grabbing a release from inside the calendar sheet, the release detail
sheet was dismissed but the underlying navigation stayed on the interactive
search results. The download handlers popped the global router path
(moviesPath/seriesPath), but navigation inside the calendar sheet is driven
by its own local NavigationPath, so the pop had no visible effect (and could
silently pop an unrelated screen in the background tab).

Extend CalendarSheetContext with a `pop` action that removes the top of the
local path, and use it in both release sheets when presented inside the
calendar sheet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XxXjrUwMf37x6Mkh9DKnxe