### PR TITLE
Add wire-format contract test for synced instances

### DIFF
--- a/Ruddarr.xcodeproj/project.pbxproj
+++ b/Ruddarr.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		FADD00000000000000000053 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD00000000000000000051 /* Placeholder.swift */; };
 		FADD00000000000000000062 /* PlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD00000000000000000061 /* PlaceholderTests.swift */; };
 		FADD00000000000000000072 /* FormatStringParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD00000000000000000071 /* FormatStringParityTests.swift */; };
+		FADD00000000000000000082 /* InstanceWireFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD00000000000000000081 /* InstanceWireFormatTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -546,6 +547,7 @@
 		FADD00000000000000000051 /* Placeholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Placeholder.swift; sourceTree = "<group>"; };
 		FADD00000000000000000061 /* PlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderTests.swift; sourceTree = "<group>"; };
 		FADD00000000000000000071 /* FormatStringParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatStringParityTests.swift; sourceTree = "<group>"; };
+		FADD00000000000000000081 /* InstanceWireFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceWireFormatTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -612,6 +614,7 @@
 				FADD00000000000000000031 /* HexEncodingTests.swift */,
 				FADD00000000000000000071 /* FormatStringParityTests.swift */,
 				FADD00000000000000000061 /* PlaceholderTests.swift */,
+				FADD00000000000000000081 /* InstanceWireFormatTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1291,6 +1294,7 @@
 				FADD00000000000000000072 /* FormatStringParityTests.swift in Sources */,
 				FADD00000000000000000053 /* Placeholder.swift in Sources */,
 				FADD00000000000000000062 /* PlaceholderTests.swift in Sources */,
+				FADD00000000000000000082 /* InstanceWireFormatTests.swift in Sources */,
 				FADD00000000000000000023 /* Formatters.swift in Sources */,
 				FADD00000000000000000044 /* HexEncoding.swift in Sources */,
 			);

--- a/Tests/InstanceWireFormatTests.swift
+++ b/Tests/InstanceWireFormatTests.swift
@@ -1,0 +1,154 @@
+import Testing
+import Foundation
+
+// Locks the cross-version wire format of the `instances` value that syncs through
+// `NSUbiquitousKeyValueStore` (key "instances", or "debugInstances" in DEBUG).
+//
+// WHY THIS EXISTS: `@CloudStorage` builds shipped before #698 remain installed in
+// the field and are *writers* to the same iCloud value. They decode it strictly:
+// `string(forKey:).flatMap([Instance].init(rawValue:)) ?? []`. If a schema change
+// makes the stored JSON undecodable by those builds, they silently read `[]` and —
+// the moment the user touches instances on that device — write `[]` back to iCloud,
+// wiping every device. See the "BE CAREFUL CHANGING" note in `Instance.swift` and
+// the adoption logic in `InstancesStore`.
+//
+// The fixtures below freeze a payload exactly as a shipped build persists it. The
+// asserted keys are the ones `Instance.init(from:)` decodes with non-optional
+// `decode(...)` — the set whose removal, rename, or retype breaks in-field builds.
+// `tags`, `name`, `version`, and `stats` are decoded optionally and may be absent.
+//
+// CONTRACT: do not edit a fixture just to make a failing build pass. A change here
+// means the wire format changed — and that change must be additive (new keys read
+// with `decodeIfPresent` + a default) or gated behind a migration that keeps old
+// builds readable. This is a structural spec (Foundation only); the host-less test
+// target can't link `Instance.swift` without its full dependency graph, so keep
+// these fixtures in lockstep with `Instance.init(from:)`.
+struct InstanceWireFormatTests {
+    // Two instances as written by a shipped `@CloudStorage` build: a Radarr in
+    // `.normal` mode and a Sonarr in `.slow` mode.
+    private let goldenPayload = """
+    [
+      {
+        "id": "6C7E1B2A-1111-2222-3333-444455556666",
+        "type": "Radarr",
+        "mode": { "normal": {} },
+        "label": "Home",
+        "url": "https://radarr.example.com",
+        "apiKey": "a1b2c3d4e5f60718293a4b5c6d7e8f90",
+        "headers": [
+          { "id": "0A1B2C3D-0001-0002-0003-000400050006", "name": "X-Proxy", "value": "ruddarr" }
+        ],
+        "rootFolders": [
+          { "id": 1, "accessible": true, "path": "/volume1/Movies", "freeSpace": 1000000000000 }
+        ],
+        "qualityProfiles": [
+          { "id": 1, "name": "HD-1080p" }
+        ],
+        "tags": [],
+        "name": "Radarr (Home)",
+        "version": "5.14.0.9383",
+        "stats": { "movies": 1234, "series": 0, "episodes": 0, "size": 987654321000 }
+      },
+      {
+        "id": "7D8E2F3A-2222-3333-4444-555566667777",
+        "type": "Sonarr",
+        "mode": { "slow": {} },
+        "label": "Seedbox",
+        "url": "https://sonarr.example.com",
+        "apiKey": "112233445566778899aabbccddeeff00",
+        "headers": [],
+        "rootFolders": [
+          { "id": 1, "accessible": true, "path": "/volume1/TV", "freeSpace": 2000000000000 }
+        ],
+        "qualityProfiles": [
+          { "id": 2, "name": "WEB-1080p" }
+        ],
+        "tags": []
+      }
+    ]
+    """
+
+    // The minimum a shipped build needs to decode an instance: every non-optional
+    // key in `Instance.init(from:)`, and nothing else.
+    private let minimalPayload = """
+    [
+      {
+        "id": "00112233-4455-6677-8899-AABBCCDDEEFF",
+        "type": "Radarr",
+        "mode": { "normal": {} },
+        "label": "",
+        "url": "https://example.com",
+        "apiKey": "key",
+        "headers": [],
+        "rootFolders": [],
+        "qualityProfiles": []
+      }
+    ]
+    """
+
+    // Keys `Instance.init(from:)` reads with non-optional `decode(...)`.
+    private let requiredKeys = [
+        "id", "type", "mode", "label", "url", "apiKey",
+        "headers", "rootFolders", "qualityProfiles",
+    ]
+
+    private func instances(_ json: String) throws -> [[String: Any]] {
+        let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        return try #require(object as? [[String: Any]])
+    }
+
+    @Test func goldenPayloadParsesAsInstanceArray() throws {
+        let parsed = try instances(goldenPayload)
+        #expect(parsed.count == 2)
+    }
+
+    @Test func everyInstanceCarriesRequiredKeysWithExpectedTypes() throws {
+        for instance in try instances(goldenPayload) {
+            for key in requiredKeys {
+                #expect(instance[key] != nil, "missing required key: \(key)")
+            }
+
+            let id = try #require(instance["id"] as? String)
+            #expect(UUID(uuidString: id) != nil, "id is not a UUID string: \(id)")
+
+            let type = try #require(instance["type"] as? String)
+            #expect(["Radarr", "Sonarr"].contains(type), "unexpected type: \(type)")
+
+            #expect(instance["label"] as? String != nil)
+            #expect(instance["url"] as? String != nil)
+            #expect(instance["apiKey"] as? String != nil)
+            #expect(instance["headers"] as? [Any] != nil)
+            #expect(instance["rootFolders"] as? [Any] != nil)
+            #expect(instance["qualityProfiles"] as? [Any] != nil)
+        }
+    }
+
+    // `InstanceMode` is a Swift-synthesized enum (SE-0295): a case with no
+    // associated values serializes as a single-key object like {"normal":{}}, NOT
+    // a bare string. Giving `InstanceMode` a raw value would silently change this
+    // to "normal" and break every in-field `@CloudStorage` decoder. Pin the shape.
+    @Test func modeIsASingleKeyObjectNotAString() throws {
+        let knownCases = ["normal", "slow", "large"]
+
+        for instance in try instances(goldenPayload) {
+            #expect(instance["mode"] as? String == nil, "mode must not be a bare string")
+
+            let mode = try #require(instance["mode"] as? [String: Any])
+            #expect(mode.count == 1, "mode must encode exactly one case")
+
+            let caseName = try #require(mode.keys.first)
+            #expect(knownCases.contains(caseName), "unknown mode case: \(caseName)")
+            #expect(mode[caseName] as? [String: Any] != nil, "mode case payload must be an object")
+        }
+    }
+
+    @Test func minimalPayloadCarriesEveryRequiredKey() throws {
+        let parsed = try instances(minimalPayload)
+        #expect(parsed.count == 1)
+
+        let instance = try #require(parsed.first)
+        for key in requiredKeys {
+            #expect(instance[key] != nil, "missing required key: \(key)")
+        }
+    }
+}


### PR DESCRIPTION
## Why

After #698, `instances` syncs through `NSUbiquitousKeyValueStore` as a JSON-encoded `[Instance]` string. The `@CloudStorage` builds shipped *before* #698 are still installed in the field and are **writers** to that same iCloud value, decoding it strictly:

```swift
string(forKey:).flatMap([Instance].init(rawValue:)) ?? []
```

If a future schema change makes the stored JSON undecodable by those builds, they silently read `[]` — and the moment the user touches instances on that device, they write `[]` back to iCloud, **wiping every device**. This is the asymmetric, hard-to-spot failure mode behind the "BE CAREFUL CHANGING" warning in `Instance.swift`.

## What

A new `Tests/InstanceWireFormatTests.swift` that freezes a payload exactly as a shipped build persists it and pins:

- the keys `Instance.init(from:)` decodes **non-optionally** (`id`, `type`, `mode`, `label`, `url`, `apiKey`, `headers`, `rootFolders`, `qualityProfiles`) — the set whose removal/rename/retype breaks in-field builds;
- the non-obvious `mode` shape: a Swift synthesized-enum single-key object (`{"normal":{}}`), **not** a bare string. Giving `InstanceMode` a raw value would silently change this and break every shipped `@CloudStorage` decoder.

A change to the wire format now shows up as an inconsistency against the frozen fixtures in review, prompting the additive-or-migration conversation instead of a silent field wipe.

## Scope / limitation

This is a **Foundation-only structural spec**, not an execution of the real `Instance` decoder: the test target is a host-less unit bundle (no `TEST_HOST` / `@testable import`), so it can't link `Instance.swift` without pulling in its full dependency graph (`Movie`, `Series`, `API`, SwiftUI). It guards the contract and serves as a ready fixture; it won't auto-fail on an `init(from:)` change unless the fixture is also touched. A true end-to-end decode test would need a small model refactor (decouple `Instance` from `Movie`/`Series`) or a host-based test target — happy to follow up if you want that.

Note: authored in an environment without a Swift toolchain, so this hasn't been compiled locally — relying on CI for the build/test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QALHa4Yvn35WYDpssrYYiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QALHa4Yvn35WYDpssrYYiG)_