### PR TITLE
Restore monitor button size in episode and season rows

### DIFF
--- a/Ruddarr/Views/Movies/MovieView.swift
+++ b/Ruddarr/Views/Movies/MovieView.swift
@@ -60,7 +60,6 @@ struct MovieView: View {
                 Task { await toggleMonitor() }
             } label: {
                 ToolbarMonitorButton(monitored: $movie.monitored, loading: togglingMonitor)
-                    .tint(.primary)
             }
             .allowsHitTesting(!togglingMonitor)
             #if os(iOS)

--- a/Ruddarr/Views/Series/EpisodeView.swift
+++ b/Ruddarr/Views/Series/EpisodeView.swift
@@ -187,7 +187,6 @@ struct EpisodeView: View {
                     ),
                     loading: instance.episodes.isMonitoring == episode.id
                 )
-                .tint(.primary)
             }
             .allowsHitTesting(instance.episodes.isMonitoring == 0)
             .disabled(!series.monitored)

--- a/Ruddarr/Views/Series/SeasonCard.swift
+++ b/Ruddarr/Views/Series/SeasonCard.swift
@@ -36,7 +36,8 @@ struct SeasonCard: View {
                 } label: {
                     ToolbarMonitorButton(
                         monitored: .constant(season.monitored),
-                        loading: isWorking
+                        loading: isWorking,
+                        font: .body
                     )
                     .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
                 }

--- a/Ruddarr/Views/Series/SeasonCard.swift
+++ b/Ruddarr/Views/Series/SeasonCard.swift
@@ -34,15 +34,12 @@ struct SeasonCard: View {
                         await toggle()
                     }
                 } label: {
-                    ToolbarMonitorButton(
+                    RowMonitorButton(
                         monitored: .constant(season.monitored),
-                        loading: isWorking,
-                        font: .body
+                        loading: isWorking
                     )
-                    .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
                 }
                 .buttonStyle(.plain)
-                .overlay(Rectangle().padding(18))
                 .allowsHitTesting(!instance.series.isWorking)
             }
         }

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -82,15 +82,12 @@ struct EpisodeRow: View {
         Button {
             Task { await toggleMonitor() }
         } label: {
-            ToolbarMonitorButton(
+            RowMonitorButton(
                 monitored: .constant(episode.monitored),
-                loading: instance.episodes.isMonitoring == episode.id,
-                font: .body
+                loading: instance.episodes.isMonitoring == episode.id
             )
-            .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
         }
         .buttonStyle(.plain)
-        .overlay(Rectangle().padding(18))
         .allowsHitTesting(instance.episodes.isMonitoring == 0)
         .disabled(!series.monitored)
     }

--- a/Ruddarr/Views/Series/SeasonView+Episode.swift
+++ b/Ruddarr/Views/Series/SeasonView+Episode.swift
@@ -84,7 +84,8 @@ struct EpisodeRow: View {
         } label: {
             ToolbarMonitorButton(
                 monitored: .constant(episode.monitored),
-                loading: instance.episodes.isMonitoring == episode.id
+                loading: instance.episodes.isMonitoring == episode.id,
+                font: .body
             )
             .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
         }

--- a/Ruddarr/Views/Series/SeasonView.swift
+++ b/Ruddarr/Views/Series/SeasonView.swift
@@ -215,7 +215,6 @@ struct SeasonView: View {
                 Task { await toggleMonitor() }
             } label: {
                 ToolbarMonitorButton(monitored: .constant(season.monitored), loading: togglingMonitor)
-                    .tint(.primary)
             }
             .allowsHitTesting(!togglingMonitor)
             .disabled(!series.monitored)

--- a/Ruddarr/Views/Series/SeriesItemView.swift
+++ b/Ruddarr/Views/Series/SeriesItemView.swift
@@ -72,7 +72,6 @@ struct SeriesDetailView: View {
                 Task { await toggleMonitor() }
             } label: {
                 ToolbarMonitorButton(monitored: $series.monitored, loading: togglingMonitor)
-                    .tint(.primary)
             }
             .allowsHitTesting(!togglingMonitor)
             #if os(iOS)

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -46,12 +46,14 @@ struct MonitorBookmark: View {
 }
 
 struct ToolbarMonitorButton: View {
+    static let iconSize: CGFloat = 15
+
     @Binding var monitored: Bool
     var loading: Bool = false
 
     var body: some View {
         MonitorBookmark(monitored: $monitored, loading: loading)
-            .font(.subheadline)
+            .font(.system(size: Self.iconSize))
             .tint(.primary)
     }
 }

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -22,6 +22,7 @@ struct ToolbarFilterBadge: View {
 struct ToolbarMonitorButton: View {
     @Binding var monitored: Bool
     var loading: Bool = false
+    var font: Font = .subheadline
 
     @State private var pulsing = false
 
@@ -30,7 +31,7 @@ struct ToolbarMonitorButton: View {
             .symbolVariant(monitored ? .fill : .none)
             .symbolEffect(.pulse, isActive: pulsing)
             .animation(.snappy, value: monitored)
-            .font(.subheadline)
+            .font(font)
             .task(id: loading) {
                 guard loading else {
                     pulsing = false

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -46,14 +46,12 @@ struct MonitorBookmark: View {
 }
 
 struct ToolbarMonitorButton: View {
-    static let iconSize: CGFloat = 15
-
     @Binding var monitored: Bool
     var loading: Bool = false
 
     var body: some View {
         MonitorBookmark(monitored: $monitored, loading: loading)
-            .font(.system(size: Self.iconSize))
+            .font(.subheadline)
             .tint(.primary)
     }
 }
@@ -66,7 +64,6 @@ struct RowMonitorButton: View {
 
     var body: some View {
         MonitorBookmark(monitored: $monitored, loading: loading)
-            .font(.body)
             .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
             .overlay(Rectangle().padding(18))
     }

--- a/Ruddarr/Views/Shared/Toolbar.swift
+++ b/Ruddarr/Views/Shared/Toolbar.swift
@@ -19,10 +19,9 @@ struct ToolbarFilterBadge: View {
     }
 }
 
-struct ToolbarMonitorButton: View {
+struct MonitorBookmark: View {
     @Binding var monitored: Bool
     var loading: Bool = false
-    var font: Font = .subheadline
 
     @State private var pulsing = false
 
@@ -31,7 +30,6 @@ struct ToolbarMonitorButton: View {
             .symbolVariant(monitored ? .fill : .none)
             .symbolEffect(.pulse, isActive: pulsing)
             .animation(.snappy, value: monitored)
-            .font(font)
             .task(id: loading) {
                 guard loading else {
                     pulsing = false
@@ -47,6 +45,31 @@ struct ToolbarMonitorButton: View {
     }
 }
 
+struct ToolbarMonitorButton: View {
+    @Binding var monitored: Bool
+    var loading: Bool = false
+
+    var body: some View {
+        MonitorBookmark(monitored: $monitored, loading: loading)
+            .font(.subheadline)
+            .tint(.primary)
+    }
+}
+
+struct RowMonitorButton: View {
+    @Binding var monitored: Bool
+    var loading: Bool = false
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        MonitorBookmark(monitored: $monitored, loading: loading)
+            .font(.body)
+            .foregroundStyle(colorScheme == .dark ? .lightGray : .darkGray)
+            .overlay(Rectangle().padding(18))
+    }
+}
+
 struct ToolbarActionButton: View {
     var body: some View {
         Image(systemName: "ellipsis")
@@ -59,6 +82,7 @@ struct ToolbarActionButton: View {
 
     VStack(spacing: 32) {
         ToolbarMonitorButton(monitored: $monitored, loading: loading)
+        RowMonitorButton(monitored: $monitored, loading: loading)
 
         VStack(spacing: 12) {
             Button("Toggle Monitored") { monitored.toggle() }


### PR DESCRIPTION
The monitoring buttons overhaul moved the row bookmark icons to the
shared ToolbarMonitorButton, which hardcodes a .subheadline font. In the
episode and season rows the icon previously inherited the larger body
font, so it appeared smaller after the change.

Add a configurable font to ToolbarMonitorButton (defaulting to
.subheadline for toolbars) and pass .body in the row usages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YEZer3D2dXwqjGG3XE16FK