### PR TITLE
Add haptic feedback to error alerts throughout the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "History" to sidebar on iPadOS
 - Show counts below media grids
 - Jump from a queue task to its movie or series
+- Play haptic feedback when an error is shown
 
 ### Changed
 - Improved byte formatting precision

--- a/Ruddarr/Utilities/View.swift
+++ b/Ruddarr/Utilities/View.swift
@@ -58,6 +58,19 @@ extension View {
     ) -> some View {
         self.modifier(DynamicPresentationDetents(detents: dynamic, selection: selection))
     }
+
+    func sensoryAlert<E: LocalizedError, A: View, M: View>(
+        isPresented: Binding<Bool>,
+        error: E?,
+        @ViewBuilder actions: (E) -> A,
+        @ViewBuilder message: (E) -> M
+    ) -> some View {
+        self
+            .alert(isPresented: isPresented, error: error, actions: actions, message: message)
+            .sensoryFeedback(.error, trigger: isPresented.wrappedValue) { _, presented in
+                presented
+            }
+    }
 }
 
 private struct OnBecomeActiveModifier: ViewModifier {

--- a/Ruddarr/Views/Activity/HistoryView.swift
+++ b/Ruddarr/Views/Activity/HistoryView.swift
@@ -55,7 +55,7 @@ struct HistoryView: View {
         .onChange(of: displayedEventType) {
             Task { await history.fetch(1, displayedEventType) }
         }
-        .alert(
+        .sensoryAlert(
             isPresented: history.errorBinding,
             error: history.error
         ) { _ in

--- a/Ruddarr/Views/Activity/TaskImportView.swift
+++ b/Ruddarr/Views/Activity/TaskImportView.swift
@@ -38,11 +38,8 @@ struct TaskImportView: View {
                 Text("No importable files found.")
             }
         }
-        .alert(
-            isPresented: Binding(
-                get: { self.error != nil },
-                set: { _ in }
-            ),
+        .sensoryAlert(
+            isPresented: Binding(get: { self.error != nil }, set: { _ in }),
             error: error
         ) { _ in
             Button("OK") { error = nil }

--- a/Ruddarr/Views/Activity/TaskRemovalView.swift
+++ b/Ruddarr/Views/Activity/TaskRemovalView.swift
@@ -40,11 +40,8 @@ struct TaskRemovalView: View {
         .toolbar {
             toolbarRemoveButton
         }
-        .alert(
-            isPresented: Binding(
-                get: { self.error != nil },
-                set: { _ in }
-            ),
+        .sensoryAlert(
+            isPresented: Binding(get: { self.error != nil }, set: { _ in }),
             error: error
         ) { _ in
             Button("OK") { error = nil }

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -56,7 +56,7 @@ struct CalendarView: View {
             .task {
                 await load()
             }
-            .alert(
+            .sensoryAlert(
                 isPresented: $alertPresented,
                 error: calendar.error
             ) { _ in

--- a/Ruddarr/Views/Movies/MovieEditView.swift
+++ b/Ruddarr/Views/Movies/MovieEditView.swift
@@ -31,7 +31,7 @@ struct MovieEditView: View {
                     undoMovieChanges()
                 }
             }
-            .alert(
+            .sensoryAlert(
                 isPresented: instance.movies.errorBinding,
                 error: instance.movies.error
             ) { _ in

--- a/Ruddarr/Views/Movies/MovieView.swift
+++ b/Ruddarr/Views/Movies/MovieView.swift
@@ -33,7 +33,7 @@ struct MovieView: View {
         .onBecomeActive {
             await reload()
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.movies.errorBinding,
             error: instance.movies.error
         ) { _ in

--- a/Ruddarr/Views/Movies/Releases/MovieReleaseSheet.swift
+++ b/Ruddarr/Views/Movies/Releases/MovieReleaseSheet.swift
@@ -45,7 +45,7 @@ struct MovieReleaseSheet: View {
                     .tint(.primary)
                 }
             }
-            .alert(
+            .sensoryAlert(
                 isPresented: instance.movies.errorBinding,
                 error: instance.movies.error
             ) { _ in

--- a/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
+++ b/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
@@ -46,7 +46,7 @@ struct MovieReleasesView: View {
         }
         .onChange(of: sort.option, updateSortDirection)
         .onChange(of: sort, updateDisplayedReleases)
-        .alert(
+        .sensoryAlert(
             isPresented: instance.releases.errorBinding,
             error: instance.releases.error
         ) { _ in

--- a/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
+++ b/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
@@ -27,7 +27,7 @@ struct MoviePreviewView: View {
         .toolbar {
             toolbarNextButton
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.movies.errorBinding,
             error: instance.movies.error
         ) { _ in

--- a/Ruddarr/Views/Movies/Search/MovieSearchView.swift
+++ b/Ruddarr/Views/Movies/Search/MovieSearchView.swift
@@ -67,7 +67,7 @@ struct MovieSearchView: View {
 
             await instance.lookup.search(query: searchRequest.query)
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.lookup.errorBinding,
             error: instance.lookup.error
         ) { _ in

--- a/Ruddarr/Views/MoviesView.swift
+++ b/Ruddarr/Views/MoviesView.swift
@@ -103,7 +103,7 @@ struct MoviesView: View {
                 guard let searchRequest, await searchRequest.waitForDebounce() else { return }
                 updateDisplayedMovies()
             }
-            .alert(isPresented: $alertPresented, error: error) { _ in
+            .sensoryAlert(isPresented: $alertPresented, error: error) { _ in
                 Button("OK") { error = nil }
             } message: { error in
                 Text(error.recoverySuggestionFallback)

--- a/Ruddarr/Views/Series/Releases/SeriesReleaseSheet.swift
+++ b/Ruddarr/Views/Series/Releases/SeriesReleaseSheet.swift
@@ -47,7 +47,7 @@ struct SeriesReleaseSheet: View {
                     .tint(.primary)
                 }
             }
-            .alert(
+            .sensoryAlert(
                 isPresented: instance.series.errorBinding,
                 error: instance.series.error
             ) { _ in

--- a/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
+++ b/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
@@ -49,7 +49,7 @@ struct SeriesReleasesView: View {
         }
         .onChange(of: sort.option, updateSortDirection)
         .onChange(of: sort, updateDisplayedReleases)
-        .alert(
+        .sensoryAlert(
             isPresented: instance.releases.errorBinding,
             error: instance.releases.error
         ) { _ in

--- a/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
@@ -27,7 +27,7 @@ struct SeriesPreviewView: View {
         .toolbar {
             toolbarNextButton
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.series.errorBinding,
             error: instance.series.error
         ) { _ in

--- a/Ruddarr/Views/Series/Search/SeriesSearchView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesSearchView.swift
@@ -64,7 +64,7 @@ struct SeriesSearchView: View {
 
             await instance.lookup.search(query: searchRequest.query)
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.lookup.errorBinding,
             error: instance.lookup.error
         ) { _ in

--- a/Ruddarr/Views/Series/SeasonView.swift
+++ b/Ruddarr/Views/Series/SeasonView.swift
@@ -54,7 +54,7 @@ struct SeasonView: View {
         .onBecomeActive {
             await reload()
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.episodes.errorBinding,
             error: instance.episodes.error
         ) { _ in
@@ -62,7 +62,7 @@ struct SeasonView: View {
         } message: { error in
             Text(error.recoverySuggestionFallback)
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.files.errorBinding,
             error: instance.files.error
         ) { _ in

--- a/Ruddarr/Views/Series/SeriesEditView.swift
+++ b/Ruddarr/Views/Series/SeriesEditView.swift
@@ -31,7 +31,7 @@ struct SeriesEditView: View {
                     undoSeriesChanges()
                 }
             }
-            .alert(
+            .sensoryAlert(
                 isPresented: instance.series.errorBinding,
                 error: instance.series.error
             ) { _ in

--- a/Ruddarr/Views/Series/SeriesItemView.swift
+++ b/Ruddarr/Views/Series/SeriesItemView.swift
@@ -45,7 +45,7 @@ struct SeriesDetailView: View {
         .onBecomeActive {
             await reload()
         }
-        .alert(
+        .sensoryAlert(
             isPresented: instance.series.errorBinding,
             error: instance.series.error
         ) { _ in

--- a/Ruddarr/Views/SeriesView.swift
+++ b/Ruddarr/Views/SeriesView.swift
@@ -104,7 +104,7 @@ struct SeriesView: View {
                 guard let searchRequest, await searchRequest.waitForDebounce() else { return }
                 updateDisplayedSeries()
             }
-            .alert(isPresented: $alertPresented, error: error) { _ in
+            .sensoryAlert(isPresented: $alertPresented, error: error) { _ in
                 Button("OK") { error = nil }
             } message: { error in
                 Text(error.recoverySuggestionFallback)

--- a/Ruddarr/Views/Settings/InstanceEditView.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView.swift
@@ -60,7 +60,7 @@ struct InstanceEditView: View {
                 await createOrUpdateInstance()
             }
         }
-        .alert(isPresented: $showingAlert, error: error) { _ in
+        .sensoryAlert(isPresented: $showingAlert, error: error) { _ in
             Button("OK") { error = nil }
         } message: { error in
             Text(error.recoverySuggestionFallback)

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -66,7 +66,7 @@ struct InstanceView: View {
         .onBecomeActive {
             await setup()
         }
-        .alert(
+        .sensoryAlert(
             isPresented: webhook.errorBinding,
             error: webhook.error
         ) { _ in

--- a/Ruddarr/Views/Shared/MediaGrid+Content.swift
+++ b/Ruddarr/Views/Shared/MediaGrid+Content.swift
@@ -81,11 +81,8 @@ struct DiscoveryGridPoster: View {
         }
         .animation(.easeInOut(duration: 0.2), value: isLoading)
         .clipShape(RoundedRectangle(cornerRadius: 14))
-        .alert(
-            isPresented: Binding(
-                get: { self.error != nil },
-                set: { _ in }
-            ),
+        .sensoryAlert(
+            isPresented: Binding(get: { self.error != nil }, set: { _ in }),
             error: error
         ) { _ in
             Button("OK") { error = nil }

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -7,6 +7,7 @@ Added
 - Added "History" to sidebar on iPadOS
 - Show counts below media grids
 - Jump from a queue task to its movie or series
+- Play haptic feedback when an error is shown
 
 Changed
 - Improved byte formatting precision


### PR DESCRIPTION
## Summary
This PR adds haptic feedback (error vibration) to all error alerts displayed throughout the application, improving user feedback when errors occur.

## Key Changes
- **New `sensoryAlert` modifier**: Added a new View extension method in `View.swift` that wraps the standard `.alert()` modifier with sensory feedback. When an alert is presented, it triggers a `.error` haptic feedback.
- **Replaced all error alerts**: Updated 23 views across the app to use the new `sensoryAlert` modifier instead of the standard `alert` modifier, including:
  - Series views (SeasonView, SeriesView, SeriesEditView, SeriesItemView, SeriesSearchView, SeriesPreviewView, SeriesReleasesView, SeriesReleaseSheet)
  - Movie views (MoviesView, MovieView, MovieEditView, MovieSearchView, MoviePreviewView, MovieReleasesView, MovieReleaseSheet)
  - Activity views (HistoryView, TaskImportView, TaskRemovalView)
  - Settings views (InstanceView, InstanceEditView)
  - Other views (CalendarView, MediaGrid+Content)
- **Updated documentation**: Added the new feature to CHANGELOG.md and TestFlight release notes

## Implementation Details
The `sensoryAlert` modifier is a generic wrapper that:
- Accepts the same parameters as the standard alert modifier (isPresented binding, error, actions, and message builders)
- Applies the standard alert functionality
- Chains a `.sensoryFeedback(.error, trigger:)` modifier that triggers whenever the alert presentation state changes to true
- Maintains full compatibility with existing alert implementations

https://claude.ai/code/session_01Pezm6oxeYoisxP8yEGiV18