### PR TITLE
Edit instances by tapping detail fields

### DIFF
--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -3280,6 +3280,16 @@
         }
       }
     },
+    "Not Set" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Set"
+          }
+        }
+      }
+    },
     "Not Subscribed" : {
       "comment" : "Status of the app subscription",
       "localizations" : {

--- a/Ruddarr/Views/Destinations.swift
+++ b/Ruddarr/Views/Destinations.swift
@@ -114,9 +114,9 @@ struct SettingsDestination: View {
                     .environment(sonarrInstance)
                     .environment(settings)
             }
-        case .editInstance(let instanceId):
+        case .editInstance(let instanceId, let advanced):
             if let instance = settings.instanceById(instanceId) {
-                InstanceEditView(mode: .update, instance: instance)
+                InstanceEditView(mode: .update, openAdvanced: advanced, instance: instance)
                     .environment(radarrInstance)
                     .environment(sonarrInstance)
                     .environment(settings)

--- a/Ruddarr/Views/Settings/InstanceEditView.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InstanceEditView: View {
     let mode: Mode
+    var openAdvanced: Bool = false
 
     @State var instance: Instance
 
@@ -52,7 +53,7 @@ struct InstanceEditView: View {
             toolbarButton
         }
         .onAppear {
-            showAdvanced = instance.mode.isSlow || !instance.headers.isEmpty
+            showAdvanced = openAdvanced || instance.mode.isSlow || !instance.headers.isEmpty
         }
         .onSubmit {
             guard !hasEmptyFields() else { return }
@@ -294,7 +295,15 @@ struct InstanceEditView: View {
         let ip = Text(verbatim: ipPlaceholder)
         let tld = Text(verbatim: tldPlaceholder)
 
-        return showAdvanced ? (url: tld, alternate: ip) : (url: ip, alternate: tld)
+        let alternate = hostIsIPAddress(instance.url) == false ? ip : tld
+        let url = hostIsIPAddress(instance.alternateURL) == true ? tld : ip
+
+        return (url: url, alternate: alternate)
+    }
+
+    func hostIsIPAddress(_ string: String) -> Bool? {
+        guard let host = NetworkInterfaces.host(of: string) else { return nil }
+        return NetworkInterfaces.parseIPv4(host) != nil || NetworkInterfaces.parseIPv6(host) != nil
     }
 
     var deleteButton: some View {

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -97,24 +97,47 @@ struct InstanceView: View {
 
     var instanceDetails: some View {
         Section {
-            LabeledContent {
-                Text(instance.label)
-            } label: {
-                Text("Label", comment: "Instance label/name")
+            editRow {
+                LabeledContent {
+                    Text(instance.label)
+                } label: {
+                    Text("Label", comment: "Instance label/name")
+                }
             }
 
-            LabeledContent("Type", value: instance.type.rawValue)
+            editRow {
+                LabeledContent("Type", value: instance.type.rawValue)
+            }
 
-            LabeledContent("URL", value: instance.url)
-                .textSelection(.enabled)
+            editRow {
+                LabeledContent("URL", value: instance.url)
+            }
 
-            if instance.candidateURLs.count > 1 {
-                LabeledContent("Alternate URL", value: instance.alternateURL)
-                    .textSelection(.enabled)
+            editRow(advanced: instance.alternateURL.isEmpty) {
+                LabeledContent("Alternate URL") {
+                    if instance.alternateURL.isEmpty {
+                        Text("Not Set").foregroundStyle(.secondary)
+                    } else {
+                        Text(instance.alternateURL)
+                    }
+                }
             }
         } footer: {
             metadataFooter
         }
+    }
+
+    func editRow<Content: View>(
+        advanced: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .contentShape(Rectangle())
+            .onTapGesture {
+                dependencies.router.settingsPath.append(
+                    SettingsView.Path.editInstance(instance.id, advanced: advanced)
+                )
+            }
     }
 
     var instanceHeaders: some View {

--- a/Ruddarr/Views/SettingsView.swift
+++ b/Ruddarr/Views/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
         case diagnostics
         case createInstance
         case viewInstance(Instance.ID)
-        case editInstance(Instance.ID)
+        case editInstance(Instance.ID, advanced: Bool = false)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

- Tap any field (Label, Type, URL, Alternate URL) on the instance detail screen to open the edit view.
- The Alternate URL row is always shown now, reading **"Not Set"** when empty. Tapping it opens the editor with **Advanced Settings already expanded**.
- Edit-view URL / Alternate URL placeholders are now content-aware: each field hints the opposite kind of address (IP vs hostname) to whatever is in the other field, instead of toggling on whether Advanced is shown.

## Implementation

- `SettingsView.Path.editInstance` gains an `advanced: Bool`, threaded through `SettingsDestination` into a new `InstanceEditView.openAdvanced` (OR'd into the existing `onAppear` show-advanced logic).
- `InstanceView` detail rows become tappable via a small `editRow` helper; the empty Alternate URL passes `advanced: true`.
- `urlPlaceholders` classifies each field's value with `NetworkInterfaces` (IP vs hostname) and shows the opposite kind in the sibling field, falling back to the classic IP-primary / hostname-alternate pairing when the sibling is empty.

## Notes

- The URL / Alternate URL rows lost `.textSelection(.enabled)` since they're now tappable buttons.

## Testing

- Verified on iOS simulator: the "Not Set" display, tap-through to the editor with Advanced expanded, and placeholders flipping correctly in both directions (IP URL → hostname placeholder, and vice versa).
- Builds pass on iOS and macOS.
