### PR TITLE
Use single placeholder for upgrade-required string

### DIFF
--- a/Ruddarr/Localizable.xcstrings
+++ b/Ruddarr/Localizable.xcstrings
@@ -5539,13 +5539,13 @@
         }
       }
     },
-    "Upgrade to %@ v%@ or newer." : {
-      "comment" : "Placeholders are instance type (Radarr/Sonarr) and version number",
+    "Upgrade to %@ or newer." : {
+      "comment" : "Placeholder is the instance type and minimum version (e.g. Sonarr v4.0.5)",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Upgrade to %@ v%@ or newer."
+            "value" : "Upgrade to %@ or newer."
           }
         }
       }

--- a/Ruddarr/Utilities/Error.swift
+++ b/Ruddarr/Utilities/Error.swift
@@ -19,10 +19,11 @@ extension AppError {
 
     static func upgradeRequired(_ type: InstanceType, to version: String) -> Self {
         let number = String(version.trimmingPrefix("v"))
+        let target = "\(type.rawValue) v\(number)"
 
         return .init(String(
-            localized: "Upgrade to \(type.rawValue) v\(number) or newer.",
-            comment: "Placeholders are instance type (Radarr/Sonarr) and version number"
+            localized: "Upgrade to \(target) or newer.",
+            comment: "Placeholder is the instance type and minimum version (e.g. Sonarr v4.0.5)"
         ))
     }
 }


### PR DESCRIPTION
Collapse the "Upgrade to %@ v%@ or newer." string into a single
"Upgrade to %@ or newer." placeholder, building the "Sonarr v4.0.5"
target text before interpolation. The rendered output is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BxpChtxWbZG8G8cm7ty3jZ