### PR TITLE
Mark queue task as importing after manual import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined various buttons designs across the app
 - Disambiguate root folder filter labels
 - Reworked the networking layer
+- Reflect queued manual imports immediately in the queue
 - Several dozen internal code improvements
 
 ### Fixed

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -72,6 +72,13 @@ class Queue {
             }
         }
 
+        recomputeDerivedState()
+
+        isLoading = false
+    }
+
+    /// Recompute the state derived from `items` (active tasks, issue count and per-media statuses).
+    private func recomputeDerivedState() {
         let active = items.values.flatMap { $0 }.filter { $0.trackedDownloadState != .imported }
         if active != self.active { self.active = active }
 
@@ -87,8 +94,6 @@ class Queue {
         if self.statuses.value != statuses {
             self.statuses.send(statuses)
         }
-
-        isLoading = false
     }
 
     private func activeStatuses() -> [QueueKey: QueueItemStatus] {
@@ -123,6 +128,8 @@ class Queue {
         }
 
         items[instanceId] = records
+
+        recomputeDerivedState()
     }
 
     func refreshDownloadClients() async {

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -112,6 +112,19 @@ class Queue {
         return statuses
     }
 
+    /// Optimistically mark a download's queue task(s) as importing after a manual
+    /// import is sent, so the UI updates immediately instead of waiting for the next poll.
+    func markImporting(_ item: QueueItem) {
+        guard let instanceId = item.instanceId, let downloadId = item.downloadId else { return }
+        guard var records = items[instanceId] else { return }
+
+        for index in records.indices where records[index].downloadId == downloadId {
+            records[index].markImporting()
+        }
+
+        items[instanceId] = records
+    }
+
     func refreshDownloadClients() async {
         for instance in instances {
             do {

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -77,7 +77,6 @@ class Queue {
         isLoading = false
     }
 
-    /// Recompute the state derived from `items` (active tasks, issue count and per-media statuses).
     private func recomputeDerivedState() {
         let active = items.values.flatMap { $0 }.filter { $0.trackedDownloadState != .imported }
         if active != self.active { self.active = active }
@@ -117,8 +116,6 @@ class Queue {
         return statuses
     }
 
-    /// Optimistically mark a download's queue task(s) as importing after a manual
-    /// import is sent, so the UI updates immediately instead of waiting for the next poll.
     func markImporting(_ item: QueueItem) {
         guard let instanceId = item.instanceId, let downloadId = item.downloadId else { return }
         guard var records = items[instanceId] else { return }

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -48,12 +48,12 @@ struct QueueItem: Codable, Identifiable, Equatable {
     let added: Date?
     var estimatedCompletionTime: Date?
 
-    let status: String?
+    var status: String?
     let statusMessages: [QueueStatusMessage]?
     let errorMessage: String?
 
-    let trackedDownloadStatus: QueueDownloadStatus?
-    let trackedDownloadState: QueueDownloadState?
+    var trackedDownloadStatus: QueueDownloadStatus?
+    var trackedDownloadState: QueueDownloadState?
 
     let outputPath: String?
     let downloadClientHasPostImportCategory: Bool?
@@ -113,6 +113,13 @@ struct QueueItem: Codable, Identifiable, Equatable {
         downloadId != nil &&
         trackedDownloadStatus == .warning &&
         [.importPending, .importBlocked].contains(trackedDownloadState)
+    }
+
+    /// Optimistically reflect a queued manual import until the next poll refreshes the queue.
+    mutating func markImporting() {
+        status = "completed"
+        trackedDownloadStatus = .ok
+        trackedDownloadState = .importing
     }
 
     var isSABnzbd: Bool {

--- a/Ruddarr/Models/Queue/QueueItem.swift
+++ b/Ruddarr/Models/Queue/QueueItem.swift
@@ -115,7 +115,6 @@ struct QueueItem: Codable, Identifiable, Equatable {
         [.importPending, .importBlocked].contains(trackedDownloadState)
     }
 
-    /// Optimistically reflect a queued manual import until the next poll refreshes the queue.
     mutating func markImporting() {
         status = "completed"
         trackedDownloadStatus = .ok

--- a/Ruddarr/Views/Activity/TaskImportView.swift
+++ b/Ruddarr/Views/Activity/TaskImportView.swift
@@ -125,6 +125,8 @@ struct TaskImportView: View {
         do {
             _ = try await dependencies.api.command(.manualImport(selectedFiles), instance)
 
+            Queue.shared.markImporting(item)
+
             dependencies.toast.show(.importQueued)
         } catch is CancellationError {
             // do nothing

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -26,6 +26,7 @@ Changed
 - Refined various buttons designs across the app
 - Disambiguate root folder filter labels
 - Reworked the networking layer
+- Reflect queued manual imports immediately in the queue
 - Several dozen internal code improvements
 
 Fixed


### PR DESCRIPTION
After sending a manual import command, optimistically update the
download task's state to "Importing" instead of leaving it in the
misleading "Import Blocked" state until the next queue poll (~5s).