### PR TITLE
Match macOS details poster size to the library grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed series files failing to load when a language was missing
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
-- Fixed poster size changing between the library grid and details on macOS
+- Fixed poster size changing between grids and details on macOS
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed series files failing to load when a language was missing
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
+- Fixed poster size changing between the library grid and details on macOS
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/Ruddarr/Models/Media.swift
+++ b/Ruddarr/Models/Media.swift
@@ -223,20 +223,20 @@ struct MediaDetailsPosterModifier: ViewModifier {
     @Environment(\.deviceType) private var deviceType
 
     func body(content: Content) -> some View {
-        if deviceType == .phone {
-            content.frame(width: posterWidth, height: posterWidth * 1.5)
-        } else {
-            content.frame(width: 200, height: 300)
-        }
+        content.frame(width: posterWidth, height: posterWidth * 1.5)
     }
 
     @MainActor private var posterWidth: CGFloat {
-        #if os(iOS)
-            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-            let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
-
-            return (scene?.keyWindow?.bounds.width ?? 390) * 0.4
+        #if os(macOS)
+            return PosterMetrics.shared.gridWidth
         #else
+            if deviceType == .phone {
+                let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+                let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+
+                return (scene?.keyWindow?.bounds.width ?? 390) * 0.4
+            }
+
             return 200
         #endif
     }

--- a/Ruddarr/Views/Movies/MovieGridPoster.swift
+++ b/Ruddarr/Views/Movies/MovieGridPoster.swift
@@ -18,6 +18,7 @@ struct MovieGridPoster: View {
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: 14))
+            .tracksGridPosterWidth()
     }
 
     var poster: some View {

--- a/Ruddarr/Views/Series/SeriesGridPoster.swift
+++ b/Ruddarr/Views/Series/SeriesGridPoster.swift
@@ -29,6 +29,7 @@ struct SeriesGridPoster: View {
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: 14))
+            .tracksGridPosterWidth()
     }
 
     var poster: some View {

--- a/Ruddarr/Views/Shared/MediaGrid+Content.swift
+++ b/Ruddarr/Views/Shared/MediaGrid+Content.swift
@@ -106,6 +106,7 @@ struct DiscoveryGridPoster: View {
         }
         .animation(.easeInOut(duration: 0.2), value: isLoading)
         .clipShape(RoundedRectangle(cornerRadius: 14))
+        .tracksGridPosterWidth()
         .sensoryAlert(
             isPresented: Binding(get: { self.error != nil }, set: { _ in }),
             error: error

--- a/Ruddarr/Views/Shared/MediaGrid.swift
+++ b/Ruddarr/Views/Shared/MediaGrid.swift
@@ -73,7 +73,8 @@ extension MediaGrid where Header == Never {
     }
 }
 
-@MainActor @Observable
+@MainActor
+@Observable
 final class PosterMetrics {
     static let shared = PosterMetrics()
 

--- a/Ruddarr/Views/Shared/MediaGrid.swift
+++ b/Ruddarr/Views/Shared/MediaGrid.swift
@@ -73,6 +73,31 @@ extension MediaGrid where Header == Never {
     }
 }
 
+@MainActor @Observable
+final class PosterMetrics {
+    static let shared = PosterMetrics()
+
+    private init() {}
+
+    var gridWidth: CGFloat = 200
+}
+
+extension View {
+    func tracksGridPosterWidth() -> some View {
+        #if os(macOS)
+            onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                if width > 0, abs(PosterMetrics.shared.gridWidth - width) > 0.5 {
+                    PosterMetrics.shared.gridWidth = width
+                }
+            }
+        #else
+            self
+        #endif
+    }
+}
+
 #Preview {
     let movies: [Movie] = PreviewData.load(name: "movies")
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -38,7 +38,7 @@ Fixed
 - Fixed series files failing to load when a language was missing
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
-- Fixed poster size changing between the library grid and details on macOS
+- Fixed poster size changing between grids and details on macOS
 
 Removed
 - Dropped support for Sonarr v3

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -38,6 +38,7 @@ Fixed
 - Fixed series files failing to load when a language was missing
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
+- Fixed poster size changing between the library grid and details on macOS
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
## Problem

On macOS the media grids size poster cells with an **adaptive** column that stretches to fill the window (`160–200pt`), while the details poster was pinned to a fixed **`200×300`**. A grid cell is therefore almost never exactly 200pt wide, so opening an item snapped the poster to a different size than the one that was tapped.

iPhone doesn't show this because its details poster is already dynamic (`windowWidth * 0.4`).

## Approach

The grid stores the width it *actually* lays out in a shared observable, and `MediaDetailsPosterModifier` reads it back — so the details poster matches the tapped cell exactly. The grids and the details view occupy the same content column, so the width carries over directly.

Measuring the rendered cell (rather than reimplementing SwiftUI's adaptive column math) keeps the two in sync automatically if the `160–200` range is ever changed, and avoids feeding a measured size back into the view that produced it — this poster has a history of layout hangs, so nothing self-sizing was introduced.

- `MediaGrid.swift` — `PosterMetrics` (`@MainActor @Observable`, single `gridWidth`) + a `tracksGridPosterWidth()` modifier reading the laid-out width via `onGeometryChange`
- `MovieGridPoster` / `SeriesGridPoster` / `DiscoveryGridPoster` — apply the modifier to the poster cell
- `Media.swift` — `MediaDetailsPosterModifier` reads `PosterMetrics.shared.gridWidth` on macOS

All three poster cells are tracked because each one opens the same details view. They share the adaptive column config and scene padding, so they report an identical width; covering all three matters when discovery or lookup is the first poster grid shown, which would otherwise leave the stored width at its default.

The tracking modifier is macOS-only (a no-op elsewhere) and guarded with a `>0.5` threshold so it cannot loop or churn. **iPhone (dynamic) and iPad (fixed 200) are unchanged.**

## Notes

- In **cards** grid mode there is no poster cell to measure, so the details poster falls back to the last measured value (or the 200 default). No jump reference exists in that mode.
- If details are opened via deeplink before any grid renders, the 200 default applies — matching today's behavior.

## Testing

`xcodebuild` passes on **macOS** and **iOS Simulator** with no new warnings. Not yet visually confirmed in a running app.