### PR TITLE
Rename `LenientDecoded` to `LossyDecoded`

### DIFF
--- a/Ruddarr/Models/Series/Episode.swift
+++ b/Ruddarr/Models/Series/Episode.swift
@@ -8,7 +8,7 @@ struct Episode: Identifiable, Codable, Equatable {
 
     let seriesId: Int
     let episodeFileId: Int
-    @LenientDecoded var episodeFile: MediaFile?
+    @LossyDecoded var episodeFile: MediaFile?
     let tvdbId: Int
 
     let seasonNumber: Int

--- a/Ruddarr/Utilities/Decoders.swift
+++ b/Ruddarr/Utilities/Decoders.swift
@@ -21,8 +21,8 @@ extension JSONDecoder.DateDecodingStrategy {
 }
 
 extension KeyedDecodingContainer {
-    func decode<T>(_ type: LenientDecoded<T>.Type, forKey key: Key) throws -> LenientDecoded<T> {
-        try decodeIfPresent(type, forKey: key) ?? LenientDecoded(wrappedValue: nil)
+    func decode<T>(_ type: LossyDecoded<T>.Type, forKey key: Key) throws -> LossyDecoded<T> {
+        try decodeIfPresent(type, forKey: key) ?? LossyDecoded(wrappedValue: nil)
     }
 
     func decodeLossyArrayIfPresent<T: Decodable>(
@@ -33,14 +33,8 @@ extension KeyedDecodingContainer {
     }
 }
 
-extension KeyedEncodingContainer {
-    mutating func encode<T>(_ value: LenientDecoded<T>, forKey key: Key) throws {
-        try encodeIfPresent(value.wrappedValue, forKey: key)
-    }
-}
-
 @propertyWrapper
-struct LenientDecoded<Wrapped: Codable & Equatable>: Codable, Equatable {
+struct LossyDecoded<Wrapped: Codable & Equatable>: Codable, Equatable {
     var wrappedValue: Wrapped?
 
     init(wrappedValue: Wrapped?) {
@@ -58,4 +52,4 @@ struct LenientDecoded<Wrapped: Codable & Equatable>: Codable, Equatable {
     }
 }
 
-extension LenientDecoded: Sendable where Wrapped: Sendable {}
+extension LossyDecoded: Sendable where Wrapped: Sendable {}

--- a/Tests/LossyDecodingTests.swift
+++ b/Tests/LossyDecodingTests.swift
@@ -51,9 +51,9 @@ struct LossyDecodingTests {
     }
 }
 
-// Exercises `LenientDecoded`, used by `Episode.episodeFile` so a malformed
+// Exercises `LossyDecoded`, used by `Episode.episodeFile` so a malformed
 // embedded file degrades to nil instead of failing the whole episodes response.
-struct LenientDecodedTests {
+struct LossyDecodedTests {
     private struct File: Codable, Equatable {
         let id: Int
         let size: Int
@@ -61,7 +61,7 @@ struct LenientDecodedTests {
 
     private struct Fixture: Codable, Equatable {
         let id: Int
-        @LenientDecoded var file: File?
+        @LossyDecoded var file: File?
     }
 
     private func decode(_ json: String) throws -> Fixture {
@@ -93,9 +93,10 @@ struct LenientDecodedTests {
         }
     }
 
-    @Test func encodingOmitsNil() throws {
-        let data = try JSONEncoder().encode(Fixture(id: 1, file: nil))
-        #expect(String(bytes: data, encoding: .utf8) == #"{"id":1}"#)
+    @Test func roundTripsNil() throws {
+        let fixture = Fixture(id: 1, file: nil)
+        let decoded = try JSONDecoder().decode(Fixture.self, from: JSONEncoder().encode(fixture))
+        #expect(decoded == fixture)
     }
 
     @Test func roundTripsValue() throws {


### PR DESCRIPTION
Internal cleanup of the decoding helper added in #740. No user-facing behavior change, so no `CHANGELOG.md` entry.

### Rename

`LenientDecoded` and its neighbor `decodeLossyArrayIfPresent` express the same idea — drop invalid data rather than fail the whole response — under two different names, six lines apart in the same file. Now both say "lossy".

### Dropped the `KeyedEncodingContainer` overload

It only changed nil from `"episodeFile": null` to an omitted key. Nothing observes that: `Episode` is never encoded anywhere in the app — the API only ever decodes it, and monitor toggles use `EpisodesMonitorResource`. The `encodingOmitsNil` test is replaced by `roundTripsNil`, which asserts the thing that actually matters.

### Kept the `KeyedDecodingContainer` overload

Worth stating explicitly, since it looks like boilerplate: it is load-bearing. Because the storage type `LossyDecoded<MediaFile>` is non-optional, the synthesized `Episode.init(from:)` emits `decode(_:forKey:)` rather than `decodeIfPresent`. Without the overload a **missing** `episodeFile` throws `keyNotFound` — and that is the common path, not an edge case: Sonarr omits the key whenever an episode has no file, and v3 omits it always.

### Not done

A breadcrumb on the swallowed error was considered — the wrapper currently degrades silently, so `MediaFile` shape drift would surface only as a missing file section. It cannot live in `Decoders.swift`: that file is compiled into the Tests target, which does not link Sentry, and `Services/Sentry.swift` pulls in `CloudKit`/`StoreKit`/`Secrets`/`dependencies`. Left for a separate change if the silence ever becomes a problem.

### Testing

`xcodebuild test` on both `platform=macOS` and `platform=iOS Simulator,name=iPhone 17 Pro` — 198 tests in 20 suites pass, no new warnings.