### PR TITLE
Surface instance metadata fetch failures

### DIFF
--- a/Ruddarr/Models/Instances/RadarrInstance.swift
+++ b/Ruddarr/Models/Instances/RadarrInstance.swift
@@ -1,5 +1,6 @@
 import os
 import SwiftUI
+import Sentry
 import Foundation
 
 @MainActor
@@ -71,7 +72,11 @@ class RadarrInstance {
             instance.rootFolders = try await rootFolders
             instance.qualityProfiles = try await qualityProfiles
             instance.tags = try await tags
+        } catch is CancellationError {
+            return nil
         } catch {
+            leaveBreadcrumb(.error, category: "radarr.metadata", message: "Metadata fetch failed", data: ["error": error])
+
             return nil
         }
 

--- a/Ruddarr/Models/Instances/RadarrInstance.swift
+++ b/Ruddarr/Models/Instances/RadarrInstance.swift
@@ -64,21 +64,40 @@ class RadarrInstance {
             return nil
         }
 
-        do {
-            async let rootFolders = dependencies.api.rootFolders(instance)
-            async let qualityProfiles = dependencies.api.qualityProfiles(instance)
-            async let tags = dependencies.api.getTags(instance)
+        async let rootFolders = dependencies.api.rootFolders(instance)
+        async let qualityProfiles = dependencies.api.qualityProfiles(instance)
+        async let tags = dependencies.api.getTags(instance)
 
+        var updated = false
+
+        do {
             instance.rootFolders = try await rootFolders
-            instance.qualityProfiles = try await qualityProfiles
-            instance.tags = try await tags
+            updated = true
         } catch is CancellationError {
             return nil
         } catch {
-            leaveBreadcrumb(.error, category: "radarr.metadata", message: "Metadata fetch failed", data: ["error": error])
-
-            return nil
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Root folders fetch failed", data: ["error": error])
         }
+
+        do {
+            instance.qualityProfiles = try await qualityProfiles
+            updated = true
+        } catch is CancellationError {
+            return nil
+        } catch {
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Quality profiles fetch failed", data: ["error": error])
+        }
+
+        do {
+            instance.tags = try await tags
+            updated = true
+        } catch is CancellationError {
+            return nil
+        } catch {
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Tags fetch failed", data: ["error": error])
+        }
+
+        guard updated else { return nil }
 
         if !movies.items.isEmpty {
             instance.stats = await InstanceStats.make(movies: movies.items)

--- a/Ruddarr/Models/Instances/SonarrInstance.swift
+++ b/Ruddarr/Models/Instances/SonarrInstance.swift
@@ -67,21 +67,40 @@ class SonarrInstance {
             return nil
         }
 
-        do {
-            async let rootFolders = dependencies.api.rootFolders(instance)
-            async let qualityProfiles = dependencies.api.qualityProfiles(instance)
-            async let tags = dependencies.api.getTags(instance)
+        async let rootFolders = dependencies.api.rootFolders(instance)
+        async let qualityProfiles = dependencies.api.qualityProfiles(instance)
+        async let tags = dependencies.api.getTags(instance)
 
+        var updated = false
+
+        do {
             instance.rootFolders = try await rootFolders
-            instance.qualityProfiles = try await qualityProfiles
-            instance.tags = try await tags
+            updated = true
         } catch is CancellationError {
             return nil
         } catch {
-            leaveBreadcrumb(.error, category: "sonarr.metadata", message: "Metadata fetch failed", data: ["error": error])
-
-            return nil
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Root folders fetch failed", data: ["error": error])
         }
+
+        do {
+            instance.qualityProfiles = try await qualityProfiles
+            updated = true
+        } catch is CancellationError {
+            return nil
+        } catch {
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Quality profiles fetch failed", data: ["error": error])
+        }
+
+        do {
+            instance.tags = try await tags
+            updated = true
+        } catch is CancellationError {
+            return nil
+        } catch {
+            leaveBreadcrumb(.error, category: "instance.metadata", message: "Tags fetch failed", data: ["error": error])
+        }
+
+        guard updated else { return nil }
 
         if !series.items.isEmpty {
             instance.stats = await InstanceStats.make(series: series.items)

--- a/Ruddarr/Models/Instances/SonarrInstance.swift
+++ b/Ruddarr/Models/Instances/SonarrInstance.swift
@@ -1,5 +1,6 @@
 import os
 import SwiftUI
+import Sentry
 import Foundation
 
 @MainActor
@@ -74,7 +75,11 @@ class SonarrInstance {
             instance.rootFolders = try await rootFolders
             instance.qualityProfiles = try await qualityProfiles
             instance.tags = try await tags
+        } catch is CancellationError {
+            return nil
         } catch {
+            leaveBreadcrumb(.error, category: "sonarr.metadata", message: "Metadata fetch failed", data: ["error": error])
+
             return nil
         }
 

--- a/Ruddarr/Views/Movies/MovieForm.swift
+++ b/Ruddarr/Views/Movies/MovieForm.swift
@@ -83,18 +83,25 @@ struct MovieForm: View {
         .tint(.secondary)
     }
 
+    @ViewBuilder
     var qualityProfileField: some View {
-        Picker(selection: $movie.qualityProfileId) {
-            ForEach(instance.qualityProfiles) { profile in
-                Text(profile.name)
+        if instance.qualityProfiles.isEmpty {
+            LabeledContent("Quality Profile") {
+                Text("Error")
             }
-        } label: {
-            ViewThatFits(in: .horizontal) {
-                Text("Quality Profile")
-                Text("Quality")
+        } else {
+            Picker(selection: $movie.qualityProfileId) {
+                ForEach(instance.qualityProfiles) { profile in
+                    Text(profile.name)
+                }
+            } label: {
+                ViewThatFits(in: .horizontal) {
+                    Text("Quality Profile")
+                    Text("Quality")
+                }
             }
+            .tint(.secondary)
         }
-        .tint(.secondary)
     }
 
 #if os(macOS)

--- a/Ruddarr/Views/Series/SeriesForm.swift
+++ b/Ruddarr/Views/Series/SeriesForm.swift
@@ -67,18 +67,25 @@ struct SeriesForm: View {
         }
     }
 
+    @ViewBuilder
     var qualityProfileField: some View {
-        Picker(selection: $series.qualityProfileId) {
-            ForEach(instance.qualityProfiles) { profile in
-                Text(profile.name).tag(Optional.some(profile.id))
+        if instance.qualityProfiles.isEmpty {
+            LabeledContent("Quality Profile") {
+                Text("Error")
             }
-        } label: {
-            ViewThatFits(in: .horizontal) {
-                Text("Quality Profile")
-                Text("Quality", comment: "Short version of Quality Profile")
+        } else {
+            Picker(selection: $series.qualityProfileId) {
+                ForEach(instance.qualityProfiles) { profile in
+                    Text(profile.name).tag(Optional.some(profile.id))
+                }
+            } label: {
+                ViewThatFits(in: .horizontal) {
+                    Text("Quality Profile")
+                    Text("Quality", comment: "Short version of Quality Profile")
+                }
             }
+            .tint(.secondary)
         }
-        .tint(.secondary)
     }
 
     var typeField: some View {


### PR DESCRIPTION
## Summary

Two small changes to diagnose reports of blank quality profile pickers:

- **RadarrInstance / SonarrInstance**: log failed metadata fetches (root folders, quality profiles, tags) as a Sentry `.error` breadcrumb with the underlying error attached. Cancellations are not logged.
- **MovieForm / SeriesForm**: display "Error" instead of the quality profile picker when no profiles are loaded, instead of a blank, untappable row.

No retry logic, no behavior changes to the fetch itself.