### PR TITLE
Keep the library filter when adding a movie or series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
 - Fixed poster size changing between grids and details on macOS
+- Fixed library filters being reset after adding a movie or series
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
+++ b/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
@@ -13,7 +13,6 @@ struct MoviePreviewView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.deviceType) private var deviceType
 
-    @AppStorage("movieSort", store: dependencies.store) var movieSort: MovieSort = .init()
     @AppStorage("movieDefaults", store: dependencies.store) var movieDefaults: MovieDefaults = .init()
 
     var body: some View {
@@ -114,7 +113,6 @@ struct MoviePreviewView: View {
         #endif
 
         presentingForm = false
-        movieSort.filter = .all
 
         let moviePath = MoviesPath.movie(addedMovie.id)
 

--- a/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
@@ -13,7 +13,6 @@ struct SeriesPreviewView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.deviceType) private var deviceType
 
-    @AppStorage("seriesSort", store: dependencies.store) var seriesSort: SeriesSort = .init()
     @AppStorage("seriesDefaults", store: dependencies.store) var seriesDefaults: SeriesDefaults = .init()
 
     var body: some View {
@@ -115,7 +114,6 @@ struct SeriesPreviewView: View {
         #endif
 
         presentingForm = false
-        seriesSort.filter = .all
 
         let seriesPath = SeriesPath.series(addedSeries.id)
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -39,6 +39,7 @@ Fixed
 - Fixed episode file details missing when opening episodes directly
 - Fixed newly added movies not being monitored
 - Fixed poster size changing between grids and details on macOS
+- Fixed library filters being reset after adding a movie or series
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
Closes #751.

Adding media reset the grid filter to "All" unconditionally, wiping a filter the user had deliberately set:

```swift
presentingForm = false
movieSort.filter = .all
```

Repro from the report: filter Movies to **Monitored**, tap **+**, add a movie, navigate back — the filter is now **All**.

### Why the reset existed

It came from #289, where it was floated speculatively — *"Maybe also reset main filter after adding a new show to avoid confusion?"* — and landed in 8ddc5a02.

What actually addressed that confusion was the other half of #289: the filter badge, which shipped 25 hours later in 31670b04 and still swaps the toolbar icon and tints it whenever a filter is active. The `Clear Filters` escape hatch in the empty state followed. The reset was belt-and-braces on top of the real fix, and it's the half that costs the user their setting.

### Why remove it rather than make it conditional

The obvious alternative is to reset only when the added item wouldn't match the active filter. It's tempting, but it decides on the `POST` response body — the least-populated snapshot of the object that will ever exist. For a freshly added series `statistics` isn't computed yet, so `episodeCount > episodeFileCount` is `0 > 0` and the **Missing** filter reads as "no match" even though the show satisfies it seconds later. That reproduces this exact bug for anyone filtered to Missing.

It also makes the behaviour unpredictable from the user's side — sometimes the filter survives, sometimes it doesn't, with nothing on screen explaining which. "Your filter is your filter" is the rule that's actually learnable.

The `@AppStorage` property existed only to feed the reset, so it goes with it — otherwise it's unused and fails the build under warnings-as-errors.

---

Net effect is two deleted lines per file. Verified with `xcodebuild build` on macOS from a clean checkout off `develop`.