### PR TITLE
Improve decode-failure reporting

### DIFF
--- a/Ruddarr/Dependencies/API/API+Error.swift
+++ b/Ruddarr/Dependencies/API/API+Error.swift
@@ -117,6 +117,18 @@ extension DecodingError {
             DecodingError.Context(codingPath: [], debugDescription: "Unhandled decoding error occurred")
         }
     }
+
+    // A failure at the root of the payload — a JSON array where an object was expected (or vice
+    // versa), or a body that isn't JSON at all — means the response isn't shaped like our API,
+    // typically a reverse proxy, auth gateway or tunnel answering instead of the instance. That is
+    // a server-side/config problem, not schema drift in a specific field, so it is not worth
+    // reporting as an app bug.
+    var isUnexpectedResponseShape: Bool {
+        switch self {
+        case .typeMismatch, .dataCorrupted: context.codingPath.isEmpty
+        default: false
+        }
+    }
 }
 
 extension FailedRequest.Reason {
@@ -127,9 +139,13 @@ extension FailedRequest.Reason {
         case .errorResponse(let code, let message):
             self = .status(code: code, message: message)
         case .decodingError(let error):
-            let path = error.context.codingPath.map(\.stringValue).joined(separator: ".")
-            let description = error.context.debugDescription
-            self = .decoding(path.isEmpty ? description : "\(path): \(description)")
+            if error.isUnexpectedResponseShape {
+                self = .decoding("Instance returned an unexpected response (a reverse proxy or gateway may be intercepting API requests)")
+            } else {
+                let path = error.context.codingPath.map(\.stringValue).joined(separator: ".")
+                let description = error.context.debugDescription
+                self = .decoding(path.isEmpty ? description : "\(path): \(description)")
+            }
         case .notConnectedToInternet:
             self = .transport("Not connected to the internet")
         case .timeoutOnPrivateIp(let error):

--- a/Ruddarr/Dependencies/API/API+Error.swift
+++ b/Ruddarr/Dependencies/API/API+Error.swift
@@ -106,26 +106,6 @@ extension API.Error: LocalizedError {
     }
 }
 
-extension DecodingError {
-    var context: DecodingError.Context {
-        switch self {
-        case .dataCorrupted(let context): context
-        case .keyNotFound(_, let context): context
-        case .typeMismatch(_, let context): context
-        case .valueNotFound(_, let context): context
-        @unknown default:
-            DecodingError.Context(codingPath: [], debugDescription: "Unhandled decoding error occurred")
-        }
-    }
-
-    var isUnexpectedResponseShape: Bool {
-        switch self {
-        case .typeMismatch, .dataCorrupted: context.codingPath.isEmpty
-        default: false
-        }
-    }
-}
-
 extension FailedRequest.Reason {
     init(_ error: API.Error) { // swiftlint:disable:this cyclomatic_complexity
         switch error {
@@ -134,11 +114,12 @@ extension FailedRequest.Reason {
         case .errorResponse(let code, let message):
             self = .status(code: code, message: message)
         case .decodingError(let error):
+            let description = error.context.debugDescription
+
             if error.isUnexpectedResponseShape {
-                self = .decoding("Instance returned an unexpected response (a reverse proxy or gateway may be intercepting API requests)")
+                self = .decoding("Unexpected response, a reverse proxy or gateway may be intercepting API requests: \(description)")
             } else {
-                let path = error.context.codingPath.map(\.stringValue).joined(separator: ".")
-                let description = error.context.debugDescription
+                let path = error.codingPathDescription
                 self = .decoding(path.isEmpty ? description : "\(path): \(description)")
             }
         case .notConnectedToInternet:

--- a/Ruddarr/Dependencies/API/API+Error.swift
+++ b/Ruddarr/Dependencies/API/API+Error.swift
@@ -118,11 +118,6 @@ extension DecodingError {
         }
     }
 
-    // A failure at the root of the payload — a JSON array where an object was expected (or vice
-    // versa), or a body that isn't JSON at all — means the response isn't shaped like our API,
-    // typically a reverse proxy, auth gateway or tunnel answering instead of the instance. That is
-    // a server-side/config problem, not schema drift in a specific field, so it is not worth
-    // reporting as an app bug.
     var isUnexpectedResponseShape: Bool {
         switch self {
         case .typeMismatch, .dataCorrupted: context.codingPath.isEmpty

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -214,8 +214,13 @@ extension API {
             do {
                 return try decoder.decode(Response.self, from: data)
             } catch let decodingError as DecodingError {
-                leaveAttachment(attemptedURL, data)
-                leaveBreadcrumb(.fatal, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
+                leaveBreadcrumb(.warning, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
+
+                // A top-level shape mismatch is a non-API response (proxy/gateway/tunnel); it is
+                // surfaced in the diagnostics failed-requests list but not reported as schema drift.
+                if !decodingError.isUnexpectedResponseShape {
+                    reportDecodingFailure(decodingError, url: attemptedURL, body: data)
+                }
 
                 throw Error.decodingError(decodingError)
             } catch {

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -214,10 +214,8 @@ extension API {
             do {
                 return try decoder.decode(Response.self, from: data)
             } catch let decodingError as DecodingError {
-                leaveBreadcrumb(.warning, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
+                leaveBreadcrumb(.error, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
 
-                // A top-level shape mismatch is a non-API response (proxy/gateway/tunnel); it is
-                // surfaced in the diagnostics failed-requests list but not reported as schema drift.
                 if !decodingError.isUnexpectedResponseShape {
                     reportDecodingFailure(decodingError, url: attemptedURL, body: data)
                 }

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -214,7 +214,7 @@ extension API {
             do {
                 return try decoder.decode(Response.self, from: data)
             } catch let decodingError as DecodingError {
-                leaveBreadcrumb(.error, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
+                leaveBreadcrumb(.warning, category: "api", message: decodingError.context.debugDescription, data: ["error": decodingError])
 
                 if !decodingError.isUnexpectedResponseShape {
                     reportDecodingFailure(decodingError, url: attemptedURL, body: data)

--- a/Ruddarr/Services/Sentry.swift
+++ b/Ruddarr/Services/Sentry.swift
@@ -66,17 +66,25 @@ func setSentryContext(for key: String, _ value: [String: Any]) {
     }
 }
 
-func leaveAttachment(_ url: URL, _ json: Data) {
+func reportDecodingFailure(_ error: DecodingError, url: URL, body: Data) {
+    guard isRunningIn(.testflight) else { return }
+
+    let path = error.context.codingPath.map(\.stringValue).joined(separator: ".")
+
+    let event = Event(level: .error)
+    event.message = SentryMessage(formatted: error.context.debugDescription)
+    event.fingerprint = ["api-decoding", path.isEmpty ? "root" : path]
+
     let basename = url.relativePath.replacingOccurrences(of: "/", with: "-")
-    let timestamp = Date().timeIntervalSince1970
 
     let attachment = Attachment(
-        data: json,
-        filename: "\(basename)-\(timestamp).json",
+        data: Data(body.prefix(64 * 1_024)),
+        filename: "\(basename).json",
         contentType: "application/json"
     )
 
-    SentrySDK.configureScope { scope in
+    // Attach the body to this event's scope only, so it never leaks onto later events.
+    SentrySDK.capture(event: event) { scope in
         scope.addAttachment(attachment)
     }
 }

--- a/Ruddarr/Services/Sentry.swift
+++ b/Ruddarr/Services/Sentry.swift
@@ -1,6 +1,7 @@
 import Sentry
 import CloudKit
 import StoreKit
+import Synchronization
 
 @MainActor
 func startSentry() {
@@ -66,21 +67,41 @@ func setSentryContext(for key: String, _ value: [String: Any]) {
     }
 }
 
+private let decodingFailureBodyLimit = 64 * 1_024
+private let reportedDecodingFailures = Mutex<Set<String>>([])
+
 func reportDecodingFailure(_ error: DecodingError, url: URL, body: Data) {
     guard isRunningIn(.testflight) else { return }
 
-    let path = error.context.codingPath.map(\.stringValue).joined(separator: ".")
+    let endpoint = url.relativePath
+    let signature = error.codingPathSignature
+    let fingerprint = ["api-decoding", endpoint, signature.isEmpty ? "root" : signature]
+
+    let unreported = reportedDecodingFailures.withLock {
+        $0.insert(fingerprint.joined(separator: " ")).inserted
+    }
+
+    guard unreported else { return }
 
     let event = Event(level: .error)
-    event.message = SentryMessage(formatted: error.context.debugDescription)
-    event.fingerprint = ["api-decoding", path.isEmpty ? "root" : path]
+    event.message = SentryMessage(formatted: maskURLs(in: error.context.debugDescription))
+    event.fingerprint = fingerprint
+    event.tags = ["endpoint": endpoint]
 
-    let basename = url.relativePath.replacingOccurrences(of: "/", with: "-")
+    let basename = endpoint.replacingOccurrences(of: "/", with: "-")
+    let truncated = body.count > decodingFailureBodyLimit
+
+    let payload: Data = if truncated {
+        // swiftlint:disable:next optional_data_string_conversion
+        Data(String(decoding: body.prefix(decodingFailureBodyLimit), as: UTF8.self).utf8)
+    } else {
+        body
+    }
 
     let attachment = Attachment(
-        data: Data(body.prefix(64 * 1_024)),
-        filename: "\(basename).json",
-        contentType: "application/json"
+        data: payload,
+        filename: truncated ? "\(basename)-truncated.txt" : "\(basename).json",
+        contentType: truncated ? "text/plain" : "application/json"
     )
 
     SentrySDK.capture(event: event) { scope in

--- a/Ruddarr/Services/Sentry.swift
+++ b/Ruddarr/Services/Sentry.swift
@@ -83,7 +83,6 @@ func reportDecodingFailure(_ error: DecodingError, url: URL, body: Data) {
         contentType: "application/json"
     )
 
-    // Attach the body to this event's scope only, so it never leaks onto later events.
     SentrySDK.capture(event: event) { scope in
         scope.addAttachment(attachment)
     }

--- a/Ruddarr/Utilities/Decoders.swift
+++ b/Ruddarr/Utilities/Decoders.swift
@@ -20,6 +20,40 @@ extension JSONDecoder.DateDecodingStrategy {
     }
 }
 
+extension DecodingError {
+    var context: DecodingError.Context {
+        switch self {
+        case .dataCorrupted(let context): context
+        case .keyNotFound(_, let context): context
+        case .typeMismatch(_, let context): context
+        case .valueNotFound(_, let context): context
+        @unknown default:
+            DecodingError.Context(codingPath: [], debugDescription: "Unhandled decoding error occurred")
+        }
+    }
+
+    var isUnexpectedResponseShape: Bool {
+        switch self {
+        case .typeMismatch, .dataCorrupted, .valueNotFound: context.codingPath.isEmpty
+        default: false
+        }
+    }
+
+    var codingPathDescription: String {
+        context.codingPath.map(\.stringValue).joined(separator: ".")
+    }
+
+    var codingPathSignature: String {
+        var components = context.codingPath.filter { $0.intValue == nil }.map(\.stringValue)
+
+        if case .keyNotFound(let key, _) = self {
+            components.append(key.stringValue)
+        }
+
+        return components.joined(separator: ".")
+    }
+}
+
 extension KeyedDecodingContainer {
     func decode<T>(_ type: LossyDecoded<T>.Type, forKey key: Key) throws -> LossyDecoded<T> {
         try decodeIfPresent(type, forKey: key) ?? LossyDecoded(wrappedValue: nil)

--- a/Tests/DecodingErrorDiagnosticsTests.swift
+++ b/Tests/DecodingErrorDiagnosticsTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+
+// Covers the `DecodingError` helpers in `Utilities/Decoders.swift` that decide how an API decode
+// failure is reported: `isUnexpectedResponseShape` gates whether it reaches Sentry at all,
+// `codingPathSignature` is the Sentry fingerprint component, and `codingPathDescription` is what
+// the failed-requests diagnostics list shows. All errors here come from a real `JSONDecoder`, so
+// the tests pin the decoder's actual behaviour rather than a hand-built approximation.
+struct DecodingErrorDiagnosticsTests {
+    private struct Item: Decodable {
+        let id: Int
+        let title: String
+        let images: [Image]?
+    }
+
+    private struct Image: Decodable {
+        let remoteUrl: String
+    }
+
+    private func failure<T: Decodable>(_ type: T.Type, _ raw: String) -> DecodingError? {
+        do {
+            _ = try JSONDecoder().decode(type, from: Data(raw.utf8))
+            return nil
+        } catch let error as DecodingError {
+            return error
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: isUnexpectedResponseShape — a body that isn't shaped like our API at all
+
+    // The canonical proxy/gateway case: an array where the endpoint returns an object.
+    @Test func rootTypeMismatchIsUnexpectedShape() throws {
+        let error = try #require(failure(Item.self, "[]"))
+
+        #expect(error.context.codingPath.isEmpty)
+        #expect(error.isUnexpectedResponseShape)
+    }
+
+    // The inverse: an object where a collection endpoint returns an array.
+    @Test func rootTypeMismatchOnArrayIsUnexpectedShape() throws {
+        let error = try #require(failure([Item].self, #"{"message": "unauthorized"}"#))
+
+        #expect(error.isUnexpectedResponseShape)
+    }
+
+    // An HTML login page, a tunnel error page — anything that isn't JSON.
+    @Test func rootDataCorruptedIsUnexpectedShape() throws {
+        let error = try #require(failure([Item].self, "<html><body>Sign in</body></html>"))
+
+        #expect(error.isUnexpectedResponseShape)
+    }
+
+    // A gateway answering `null`: no value where the payload should be.
+    @Test func rootValueNotFoundIsUnexpectedShape() throws {
+        let error = try #require(failure([Item].self, "null"))
+
+        #expect(error.isUnexpectedResponseShape)
+    }
+
+    // Genuine field-level drift must stay reportable — the whole point of the classifier.
+    @Test func missingFieldIsNotUnexpectedShape() throws {
+        let error = try #require(failure([Item].self, #"[{"id": 1}]"#))
+
+        #expect(!error.isUnexpectedResponseShape)
+    }
+
+    @Test func wrongFieldTypeIsNotUnexpectedShape() throws {
+        let error = try #require(failure([Item].self, #"[{"id": "one", "title": "A"}]"#))
+
+        #expect(!error.isUnexpectedResponseShape)
+    }
+
+    // A top-level key vanishing from an object response is drift, not a foreign body: the payload
+    // is still shaped like ours. Only `keyNotFound` is deliberately excluded from the classifier.
+    @Test func missingRootKeyIsNotUnexpectedShape() throws {
+        let error = try #require(failure(Item.self, #"{"id": 1}"#))
+
+        #expect(error.context.codingPath.isEmpty)
+        #expect(!error.isUnexpectedResponseShape)
+    }
+
+    // MARK: codingPathSignature — the Sentry fingerprint, stable across items
+
+    // JSONDecoder names array elements "Index 3" / "Index 47", so an unfiltered path would give
+    // every drifted row in a library its own Sentry issue. The signature drops them.
+    @Test func signatureDropsArrayIndices() throws {
+        let third = try #require(failure([Item].self, #"[{"id":1,"title":"A"},{"id":2,"title":"B"},{"id":"x","title":"C"}]"#))
+        let first = try #require(failure([Item].self, #"[{"id":"x","title":"C"}]"#))
+
+        #expect(third.codingPathDescription == "Index 2.id")
+        #expect(third.codingPathSignature == "id")
+        #expect(first.codingPathSignature == third.codingPathSignature)
+    }
+
+    @Test func signatureKeepsNestedFieldNames() throws {
+        let error = try #require(failure(
+            [Item].self,
+            #"[{"id":1,"title":"A","images":[{"remoteUrl":7}]}]"#
+        ))
+
+        #expect(error.codingPathSignature == "images.remoteUrl")
+    }
+
+    // `keyNotFound` carries the missing key as an associated value, not in `context.codingPath`,
+    // so without appending it two different missing fields would share one fingerprint.
+    @Test func signatureAppendsMissingKey() throws {
+        let title = try #require(failure([Item].self, #"[{"id": 1}]"#))
+        let id = try #require(failure([Item].self, #"[{"title": "A"}]"#))
+
+        #expect(title.codingPathSignature == "title")
+        #expect(id.codingPathSignature == "id")
+        #expect(title.codingPathSignature != id.codingPathSignature)
+    }
+
+    @Test func signatureIsEmptyForRootFailures() throws {
+        let error = try #require(failure([Item].self, "<html>"))
+
+        #expect(error.codingPathSignature.isEmpty)
+    }
+
+    // MARK: codingPathDescription — what the diagnostics list shows, indices included
+
+    // The human-facing path keeps the index: it points at the row a user can go inspect.
+    @Test func descriptionKeepsArrayIndices() throws {
+        let error = try #require(failure(
+            [Item].self,
+            #"[{"id":1,"title":"A"},{"id":2,"title":"B","images":[{"remoteUrl":7}]}]"#
+        ))
+
+        #expect(error.codingPathDescription == "Index 1.images.Index 0.remoteUrl")
+    }
+}


### PR DESCRIPTION
## What

Reworks how the API layer handles a `2xx` response whose body fails to decode.

- **Classifies non-API responses.** A top-level shape mismatch — a JSON array where an object is expected, or a body that isn't JSON at all — means the response isn't shaped like our API, usually a reverse proxy, auth gateway or tunnel answering instead of the instance. `DecodingError.isUnexpectedResponseShape` detects this (root-level `typeMismatch`/`dataCorrupted`).
- **Keeps config problems out of Sentry.** Those unexpected-shape responses stay in the local failed-requests diagnostics with a clearer `Reason` message ("a reverse proxy or gateway may be intercepting API requests"), but are no longer reported as schema drift.
- **Fixes the global-scope attachment leak.** Genuine field-level drift now goes through `reportDecodingFailure`, which attaches the response body **scoped to that single event** instead of `SentrySDK.configureScope` (which leaked the body onto every subsequent event).
- **Reduces severity/noise.** Reports at `.error` instead of `.fatal`, caps the attached body at 64 KB, and fingerprints by coding path so Sentry groups by the drifted field.

## Why

Previously every 2xx decode failure was reported `.fatal` with the raw body pinned to the global scope — including non-API responses from proxies/gateways, which are the user's network config rather than an app bug.

## Test plan

- macOS `xcodebuild build` succeeds with no warnings.

## Follow-ups (not in this PR)

- Retire the now-redundant `"data was not valid JSON"` string-match in `shouldReportEvent` (superseded by `isUnexpectedResponseShape`).
- Optional dedupe/rate-limit for a drifting polling endpoint (e.g. queue).