### PR TITLE
Fix freeleech-only releases not showing flags in series search

### DIFF
--- a/Ruddarr/Models/Series/SeriesReleases.swift
+++ b/Ruddarr/Models/Series/SeriesReleases.swift
@@ -222,7 +222,7 @@ struct SeriesRelease: Identifiable, Codable {
     }
 
     var releaseFlags: [SeriesReleaseFlag] {
-        guard let flags = indexerFlags, flags > 1 else {
+        guard let flags = indexerFlags, flags > 0 else {
             return []
         }
 


### PR DESCRIPTION
Fixes #755.

`SeriesRelease.releaseFlags` guards on `flags > 1`, but freeleech is bit `1`, so a release whose only flag is freeleech returns an empty array. That leaves it without a freeleech indicator in the release list, and the Freeleech filter doesn't match it either.

`SeriesReleaseFlags.map` already maps `1: .freeleech`, so parsing handles the value, only the guard rejects it. Changed to `flags > 0` so `0` still short-circuits and everything else goes to the parser.

`series-releases.json` already contains releases with `indexerFlags: 1`.

Movies use a separate string-based path and aren't affected.
