### PR TITLE
add changelog entry for series freeleech flag fix (#756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed newly added movies not being monitored
 - Fixed poster size changing between grids and details on macOS
 - Fixed library filters being reset after adding a movie or series
+- Fixed freeleech flag missing from series releases
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -40,6 +40,7 @@ Fixed
 - Fixed newly added movies not being monitored
 - Fixed poster size changing between grids and details on macOS
 - Fixed library filters being reset after adding a movie or series
+- Fixed freeleech flag missing from series releases
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
Fixes the missing `Unreleased` entry for PR #756, which corrected
`SeriesRelease.releaseFlags` dropping releases whose only indexer
flag is freeleech.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ndvQp91XVcZAnr5bXL2z6