### PR TITLE
Fix empty state flashing after release search

### DIFF
--- a/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
+++ b/Ruddarr/Views/Movies/Releases/MovieReleasesView.swift
@@ -41,7 +41,7 @@ struct MovieReleasesView: View {
             releases = []
             sort.search = ""
             await instance.releases.search(movie)
-            updateDisplayedReleases()
+            releases = sort.filterAndSortItems(instance.releases.items, movie)
             fetched = movie.id
         }
         .onChange(of: sort.option, updateSortDirection)

--- a/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
+++ b/Ruddarr/Views/Series/Releases/SeriesReleasesView.swift
@@ -44,7 +44,7 @@ struct SeriesReleasesView: View {
             sort.search = ""
             sort.seasonPack = seasonId == nil ? .episode : .season
             await instance.releases.search(series, seasonId, episodeId)
-            updateDisplayedReleases()
+            releases = sort.filterAndSortItems(instance.releases.items, series)
             fetched = (series.id, seasonId, episodeId)
         }
         .onChange(of: sort.option, updateSortDirection)


### PR DESCRIPTION
## Problem

After an interactive search finishes, the "No Releases Match" `ContentUnavailableView` flashes before the rows appear.

`updateDisplayedReleases()` wraps its entire body in a `Task` + 10 ms sleep, so it returns before assigning `releases`. The `.task` then set `fetched` immediately, leaving at least one committed frame where:

- `instance.releases.isSearching == false`
- `instance.releases.items` is populated
- `hasFetched == true`
- `releases` is still `[]`

…which falls through the overlay chain to the third branch. Instrumented in a standalone repro of the same view structure:

```
  315.6ms  search() done: items=400 isSearching=false
  315.7ms  .task body finished (fetched=1, releases=0)
  317.5ms  *** noMatchingReleases APPEAR ***
  329.7ms  deferred Task: releases = 400
  366.2ms  *** noMatchingReleases DISAPPEAR ***
```

## Fix

One line per view: filter and sort synchronously in the `.task` load path, so `releases` and `fetched` land in the same main-actor turn and no frame can observe them disagreeing. Returning from an awaited same-actor `async` call is not a suspension point, so `isSearching = false` → `releases` → `fetched` complete uninterrupted.

Only the initial load flashed. On filter/sort/search changes `releases` still holds the previous non-empty result during the deferral, so those paths never rendered an empty state and are untouched.

## Why this can't reintroduce the #434 freeze

The #434 mechanism is now established from the artifacts attached to that issue. The Instruments trace captured the freeze live: 146 s inside a single never-returning `GraphHost.flushTransactions()`, entered from `UISheetPresentationController _transitionWillBegin:` (tapping a release), looping ~105×/s: `onChange(of: sort)` → synchronous `updateDisplayedReleases()` → `releases` write queued inside the in-flight flush → full List re-diff → `onChange` re-evaluates → repeat — sustained by the old rawValue-based `==` with unstable JSON key order answering "changed" forever. The crash log matches (`0x8BADF00D`, main thread mid-flush in a List-row button).

Both legs of that loop are dead: the 10 ms deferral (which broke the write-inside-flush edge) is untouched by this PR, and the manual field-wise `==` from `23a1d43b` (which killed the unstable comparator) covers every stored field on both sort structs. **The `.task` load path this PR changes appears in zero of the trace's 139,417 hang samples.** It runs once per screen (guarded by `hasFetched`), nothing it writes can re-trigger it, and its write executes in a plain main-actor job outside any view update — the same context the deferred write always used, minus 10 ms.

Additionally verified: an optimized (`swiftc -O`) harness replicating the full structure (AppStorage JSON round-trips, deferred `onChange`, the new synchronous load-path write) produced zero hangs under 10k–30k items, kHz-rate sort-mutation storms, cancellation churn, and two views racing on a shared model — old and new shape statistically indistinguishable.

A structural alternative (deriving `releases` per body evaluation, removing the sleep entirely) was prototyped and rejected: it shifts work from data-change frequency to render frequency, which is the wrong shape for energy use.

## Notes

- Any remaining perceived delay is the spinner holding through the first List layout instead of wrong content. If a real gap survives, the unmeasured suspect is the toolbar `Menu`/`Picker` materialization over the filter arrays repopulated by `setFilterData()` — needs an `os_signpost` trace.
- On-device Release-build check (open a release list, tap a release, scroll, change sorts) recommended as routine TestFlight confirmation, not a merge blocker — the diff is two lines and trivially revertible.
- `xcodebuild -destination 'platform=macOS'` passes.