### PR TITLE
add dot shorthand for settings label style

### DIFF
--- a/Ruddarr/Views/Settings/SettingsAboutSection.swift
+++ b/Ruddarr/Views/Settings/SettingsAboutSection.swift
@@ -28,14 +28,14 @@ struct SettingsAboutSection: View {
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(settings.theme.tint, .primary)
             }
-            .labelStyle(SettingsIconLabelStyle())
+            .labelStyle(.settingsIcon)
         }
     }
 
     var share: some View {
         ShareLink(item: Links.AppShare) {
             Label("Share App", systemImage: "square.and.arrow.up")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }
     }
 
@@ -44,14 +44,14 @@ struct SettingsAboutSection: View {
             .init(name: "action", value: "write-review"),
         ])) {
             Label("Leave a Review", systemImage: "star.fill")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }
     }
 
     var macOS: some View {
         Link(destination: Links.TestFlight) {
             Label("TestFlight for macOS", systemImage: "macwindow.and.pointer.arrow")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }
     }
 }

--- a/Ruddarr/Views/Settings/SettingsContributeSection.swift
+++ b/Ruddarr/Views/Settings/SettingsContributeSection.swift
@@ -21,28 +21,28 @@ struct SettingsContributeSection: View {
     var discord: some View {
         Link(destination: Links.Discord) {
             Label("Join the Discord", systemImage: "text.bubble")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }
     }
 
     var translate: some View {
         Link(destination: Links.Crowdin, label: {
             Label("Translate the App", systemImage: "globe.europe.africa")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         })
     }
 
     var contribute: some View {
         Link(destination: Links.GitHub, label: {
             Label("Contribute on GitHub", systemImage: "curlybraces")
-                .labelStyle(SettingsIconLabelStyle(iconScale: 0.85))
+                .labelStyle(.settingsIcon(iconScale: 0.85))
         })
     }
 
     var reportIssues: some View {
         Link(destination: Links.GitHubIssues, label: {
             Label("Report an Issue", systemImage: "exclamationmark.bubble")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         })
     }
 }

--- a/Ruddarr/Views/Settings/SettingsDisplaySection.swift
+++ b/Ruddarr/Views/Settings/SettingsDisplaySection.swift
@@ -34,7 +34,7 @@ struct SettingsDisplaySection: View {
             }
 
             Label("Appearance", systemImage: icon)
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }.tint(.secondary)
     }
 
@@ -53,7 +53,7 @@ struct SettingsDisplaySection: View {
             }
         } label: {
             Label("Accent Color", systemImage: "paintpalette")
-                .labelStyle(SettingsIconLabelStyle(iconScale: 0.85))
+                .labelStyle(.settingsIcon(iconScale: 0.85))
         } currentValueLabel: {
             Text(verbatim: settings.theme.label)
         }
@@ -69,7 +69,7 @@ struct SettingsDisplaySection: View {
                 Text(settings.icon.label)
             } label: {
                 Label("App Icon", systemImage: "app.grid")
-                    .labelStyle(SettingsIconLabelStyle(iconScale: 1.05))
+                    .labelStyle(.settingsIcon(iconScale: 1.05))
             }
         }
     }

--- a/Ruddarr/Views/Settings/SettingsLinksSection.swift
+++ b/Ruddarr/Views/Settings/SettingsLinksSection.swift
@@ -22,7 +22,7 @@ struct SettingsLinksSection: View {
             destination: url,
             label: {
                 Label(name, systemImage: "arrow.up.right")
-                    .labelStyle(SettingsIconLabelStyle(iconScale: 0.85))
+                    .labelStyle(.settingsIcon(iconScale: 0.85))
             }
         )
         #if os(macOS)

--- a/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
+++ b/Ruddarr/Views/Settings/SettingsPreferencesSection.swift
@@ -55,7 +55,7 @@ struct SettingsPreferencesSection: View {
                 String(localized: "Home", comment: "(Preferences) Home tab"),
                 systemImage: "house"
             )
-            .labelStyle(SettingsIconLabelStyle())
+            .labelStyle(.settingsIcon)
         }
         .tint(.secondary)
     }
@@ -70,7 +70,7 @@ struct SettingsPreferencesSection: View {
             }
         } label: {
             Label("Grid", systemImage: "square.grid.2x2")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }.tint(.secondary)
     }
 
@@ -84,7 +84,7 @@ struct SettingsPreferencesSection: View {
             }
         } label: {
             Label("Release Filters", systemImage: "line.3.horizontal.decrease")
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
         }
         .tint(.secondary)
     }
@@ -104,7 +104,7 @@ struct SettingsPreferencesSection: View {
                 } icon: {
                     icon
                 }
-                .labelStyle(SettingsIconLabelStyle())
+                .labelStyle(.settingsIcon)
             }
             .buttonStyle(.plain)
         #else
@@ -119,7 +119,7 @@ struct SettingsPreferencesSection: View {
                     } icon: {
                         icon
                     }
-                    .labelStyle(SettingsIconLabelStyle())
+                    .labelStyle(.settingsIcon)
                 }
             }
             .foregroundStyle(.label)

--- a/Ruddarr/Views/Shared/SettingsIconLabelStyle.swift
+++ b/Ruddarr/Views/Shared/SettingsIconLabelStyle.swift
@@ -18,7 +18,17 @@ struct SettingsIconLabelStyle: LabelStyle {
     }
 }
 
+extension LabelStyle where Self == SettingsIconLabelStyle {
+    static var settingsIcon: Self {
+        .init()
+    }
+
+    static func settingsIcon(iconScale: CGFloat) -> Self {
+        .init(iconScale: iconScale)
+    }
+}
+
 #Preview {
     Label(String("Home"), systemImage: "house")
-        .labelStyle(SettingsIconLabelStyle(iconScale: 0.8))
+        .labelStyle(.settingsIcon(iconScale: 0.8))
 }


### PR DESCRIPTION
Extracts the `SettingsIconLabelStyle` refactor out of the release-layouts branch into its own standalone change.

## What

- Add `.settingsIcon` and `.settingsIcon(iconScale:)` `LabelStyle` conveniences on `LabelStyle where Self == SettingsIconLabelStyle`.
- Migrate every call site off the explicit `SettingsIconLabelStyle(...)` initializer to the dot shorthand.

Pure refactor — no user-facing behavior change, so no `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)