### PR TITLE
Add browser-aware web URL resolution for instance access

### DIFF
--- a/Ruddarr/Models/Instances/Instance.swift
+++ b/Ruddarr/Models/Instances/Instance.swift
@@ -103,8 +103,8 @@ struct Instance: Identifiable, Equatable, Codable {
         return url
     }
 
-    func webURL() async -> URL? {
-        (try? await baseURL()) ?? URL(string: url)
+    func reachableWebURL() async -> URL? {
+        await InstanceResolver.shared.reachableWebURL(for: self)
     }
 
     func isPrivateIp(primaryOnly: Bool = false) -> Bool {

--- a/Ruddarr/Services/InstanceResolver.swift
+++ b/Ruddarr/Services/InstanceResolver.swift
@@ -158,15 +158,23 @@ actor InstanceResolver {
     /// an address a browser would be turned away from. A genuine Radarr/Sonarr answer (the same
     /// verdict the routing probe uses: HTTP success, from the host that was asked, carrying
     /// `{"status": "OK"}`) is `verified`; anything else that still produced a response is
-    /// `answered` rather than dead, because the browser may hold a session this check cannot see.
+    /// `answered` rather than dead, because the browser may hold a session this check cannot see —
+    /// including a request that only failed once it had been redirected off the probed host.
     private static func webVerdict(_ base: String) async -> WebVerdict {
         guard let url = ResolverRouting.probeURL(for: base) else { return .dead }
 
-        guard let (data, response) = try? await webCheckSession.data(from: url),
-              let http = response as? HTTPURLResponse
-        else {
+        let data: Data
+        let response: URLResponse
+
+        do {
+            (data, response) = try await webCheckSession.data(from: url)
+        } catch let error as URLError {
+            return failedPastOrigin(error, probing: url) ? .answered : .dead
+        } catch {
             return .dead
         }
+
+        guard let http = response as? HTTPURLResponse else { return .dead }
 
         let verified = ResolverRouting.probeVerdict(
             status: http.statusCode,
@@ -176,6 +184,22 @@ actor InstanceResolver {
         )
 
         return verified ? .verified : .answered
+    }
+
+    /// Whether the request got *past* the probed host before failing: the origin answered with a
+    /// redirect and it was the chain that broke — a dead identity provider, or a loop between the
+    /// two. The candidate is alive, and a browser holding a session would never be sent down that
+    /// chain at all, so it is `answered` rather than `dead`.
+    private static func failedPastOrigin(_ error: URLError, probing url: URL) -> Bool {
+        if error.code == .httpTooManyRedirects { return true }
+
+        guard let failing = error.failingURL?.host(percentEncoded: false),
+              let probed = url.host(percentEncoded: false)
+        else {
+            return false
+        }
+
+        return failing.caseInsensitiveCompare(probed) != .orderedSame
     }
 
     /// Ephemeral (no cookies, no cache) so nothing stored can make a dead URL look alive, and

--- a/Ruddarr/Services/InstanceResolver.swift
+++ b/Ruddarr/Services/InstanceResolver.swift
@@ -24,6 +24,11 @@ import Foundation
 ///   transition (failed probes retry on the same throttle as failed lookups).
 /// - Self-correcting: on a fast failure, `API.request` calls `failover(afterFailing:for:)`,
 ///   which demotes that base for the current network and returns the instance's next-best one.
+/// - Browser-aware: `reachableWebURL(for:)` answers a different question — which URL a *browser*
+///   can open — by checking every candidate unauthenticated, so the app's own credentials and
+///   headers can't vouch for a URL Safari would be turned away from. Safari's own cookies are
+///   outside the app container and unreadable, so a host that answers *anything* is preferred
+///   over one that answers nothing; only a URL nothing can reach is treated as unreachable.
 ///
 /// The resolved URL is purely runtime state and is never persisted, so it can never reach
 /// iCloud, the App Group, or another device.
@@ -58,13 +63,14 @@ actor InstanceResolver {
         return result.ordered.first ?? candidates.first ?? instance.url
     }
 
-    /// The base URL `resolve` would return right now, ranked from cached state only — a pure
-    /// read for passive UI that claims no lookups and dispatches no probes.
-    func currentSelection(for instance: Instance) -> String {
+    /// Every candidate of `instance`, best first, ranked from cached state only — a pure read
+    /// that claims no lookups and dispatches no probes, for passive UI and for the web-interface
+    /// check, which wants the whole ladder rather than just its top.
+    func rankedCandidates(for instance: Instance) -> [String] {
         let candidates = instance.candidateURLs
 
         guard candidates.count > 1 else {
-            return candidates.first ?? instance.url
+            return candidates
         }
 
         let snapshot = NetworkSnapshot.capture()
@@ -72,7 +78,13 @@ actor InstanceResolver {
             &state, candidates: candidates, snapshot: snapshot, fingerprint: snapshot.fingerprint, now: Date()
         )
 
-        return ordered.first ?? candidates.first ?? instance.url
+        return ordered.isEmpty ? candidates : ordered
+    }
+
+    /// The base URL `resolve` would return right now, ranked from cached state only — a pure
+    /// read for passive UI that claims no lookups and dispatches no probes.
+    func currentSelection(for instance: Instance) -> String {
+        rankedCandidates(for: instance).first ?? instance.url
     }
 
     /// The network changed (Wi-Fi/VPN/cellular). Drop everything learned about the old one so
@@ -108,6 +120,77 @@ actor InstanceResolver {
         guard !state.demotedUntil.isEmpty else { return }
         ResolverRouting.noteSuccess(&state, for: url.absoluteString, candidates: candidates)
     }
+
+    /// What a candidate's check found, in preference order. The middle case is the one that
+    /// matters: the app cannot see Safari's cookies (they live outside the app container, and
+    /// neither `URLSession` nor `WKWebView` can read them), so an address that turns *us* away
+    /// may still let the browser straight in on a session it already holds. A host that answers
+    /// at all is therefore never written off — only outranked.
+    private enum WebVerdict {
+        case verified   // a genuine Radarr/Sonarr `/ping` — the interface is served here
+        case answered   // some response: a redirect to an identity provider, a 403, a login page
+        case dead       // nothing at all — refused, timed out, or the name didn't resolve
+    }
+
+    /// The instance's web interface at a URL worth handing to a browser, or `nil` when nothing
+    /// answered anywhere. Selection alone can't decide this: it knows which address the *app*
+    /// should talk to, having authenticated, and says nothing about what a browser gets there.
+    ///
+    /// Candidates are checked best-ranked first, and a verified one ends it — so at home the LAN
+    /// URL wins outright and the remote is never even contacted. Falling back to a host that
+    /// merely answered is what keeps an access-proxied URL usable away from home.
+    nonisolated func reachableWebURL(for instance: Instance) async -> URL? {
+        var answered: String?
+
+        for base in await rankedCandidates(for: instance) {
+            switch await Self.webVerdict(base) {
+            case .verified: return URL(string: base)
+            case .answered: answered = answered ?? base
+            case .dead: continue
+            }
+        }
+
+        return answered.flatMap { URL(string: $0) }
+    }
+
+    /// One candidate's browser-facing check: an unauthenticated `GET {base}/ping` — no API key,
+    /// no custom headers, no stored cookies — so the instance's own credentials can't vouch for
+    /// an address a browser would be turned away from. A genuine Radarr/Sonarr answer (the same
+    /// verdict the routing probe uses: HTTP success, from the host that was asked, carrying
+    /// `{"status": "OK"}`) is `verified`; anything else that still produced a response is
+    /// `answered` rather than dead, because the browser may hold a session this check cannot see.
+    private static func webVerdict(_ base: String) async -> WebVerdict {
+        guard let url = ResolverRouting.probeURL(for: base) else { return .dead }
+
+        guard let (data, response) = try? await webCheckSession.data(from: url),
+              let http = response as? HTTPURLResponse
+        else {
+            return .dead
+        }
+
+        let verified = ResolverRouting.probeVerdict(
+            status: http.statusCode,
+            finalHost: http.url?.host(percentEncoded: false),
+            probedHost: url.host(percentEncoded: false),
+            body: data
+        )
+
+        return verified ? .verified : .answered
+    }
+
+    /// Ephemeral (no cookies, no cache) so nothing stored can make a dead URL look alive, and
+    /// more patient than the routing probe: nothing waits on this check, but a candidate wrongly
+    /// called dead greys out the button, so a slow remote host is given room to answer.
+    private static let webCheckSession: URLSession = {
+        let timeout: TimeInterval = 5
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = timeout
+        configuration.timeoutIntervalForResource = timeout
+        configuration.waitsForConnectivity = false
+
+        return URLSession(configuration: configuration)
+    }()
 
     /// A structured snapshot of the current network and, for each instance, why every candidate
     /// URL ranks where it does — unmasked, for the diagnostics screen to mask on demand.

--- a/Ruddarr/Services/InstanceResolver.swift
+++ b/Ruddarr/Services/InstanceResolver.swift
@@ -157,24 +157,18 @@ actor InstanceResolver {
     /// no custom headers, no stored cookies — so the instance's own credentials can't vouch for
     /// an address a browser would be turned away from. A genuine Radarr/Sonarr answer (the same
     /// verdict the routing probe uses: HTTP success, from the host that was asked, carrying
-    /// `{"status": "OK"}`) is `verified`; anything else that still produced a response is
-    /// `answered` rather than dead, because the browser may hold a session this check cannot see —
-    /// including a request that only failed once it had been redirected off the probed host.
+    /// `{"status": "OK"}`) is `verified`; any other response — a redirect, a 403, a login page —
+    /// is `answered` rather than dead, because the browser may hold a session this check cannot
+    /// see. Redirects are never followed, so the verdict is the origin's own answer and can't
+    /// turn on whether some host further down a chain happens to be up.
     private static func webVerdict(_ base: String) async -> WebVerdict {
         guard let url = ResolverRouting.probeURL(for: base) else { return .dead }
 
-        let data: Data
-        let response: URLResponse
-
-        do {
-            (data, response) = try await webCheckSession.data(from: url)
-        } catch let error as URLError {
-            return failedPastOrigin(error, probing: url) ? .answered : .dead
-        } catch {
+        guard let (data, response) = try? await webCheckSession.data(from: url),
+              let http = response as? HTTPURLResponse
+        else {
             return .dead
         }
-
-        guard let http = response as? HTTPURLResponse else { return .dead }
 
         let verified = ResolverRouting.probeVerdict(
             status: http.statusCode,
@@ -186,25 +180,22 @@ actor InstanceResolver {
         return verified ? .verified : .answered
     }
 
-    /// Whether the request got *past* the probed host before failing: the origin answered with a
-    /// redirect and it was the chain that broke — a dead identity provider, or a loop between the
-    /// two. The candidate is alive, and a browser holding a session would never be sent down that
-    /// chain at all, so it is `answered` rather than `dead`.
-    private static func failedPastOrigin(_ error: URLError, probing url: URL) -> Bool {
-        if error.code == .httpTooManyRedirects { return true }
-
-        guard let failing = error.failingURL?.host(percentEncoded: false),
-              let probed = url.host(percentEncoded: false)
-        else {
-            return false
+    /// Hands the origin's redirect back as the task's response instead of following it, so a
+    /// candidate is judged only by the host that was actually asked.
+    private final class NoRedirects: NSObject, URLSessionTaskDelegate {
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest
+        ) async -> URLRequest? {
+            nil
         }
-
-        return failing.caseInsensitiveCompare(probed) != .orderedSame
     }
 
     /// Ephemeral (no cookies, no cache) so nothing stored can make a dead URL look alive, and
     /// more patient than the routing probe: nothing waits on this check, but a candidate wrongly
-    /// called dead greys out the button, so a slow remote host is given room to answer.
+    /// called dead is passed over for a worse one, so a slow remote host is given room to answer.
     private static let webCheckSession: URLSession = {
         let timeout: TimeInterval = 5
 
@@ -213,7 +204,7 @@ actor InstanceResolver {
         configuration.timeoutIntervalForResource = timeout
         configuration.waitsForConnectivity = false
 
-        return URLSession(configuration: configuration)
+        return URLSession(configuration: configuration, delegate: NoRedirects(), delegateQueue: nil)
     }()
 
     /// A structured snapshot of the current network and, for each instance, why every candidate

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -29,7 +29,6 @@ struct InstanceView: View {
     @State var diskSpaceExpanded: Bool = false
 
     @State var webAccessURL: URL?
-    @State var webAccessToken: UUID?
 
     @Environment(AppSettings.self) var settings
     @Environment(RadarrInstance.self) var radarrInstance
@@ -77,17 +76,6 @@ struct InstanceView: View {
         }
         .onBecomeActive {
             await setup()
-        }
-        .task(id: webAccessToken) {
-            guard webAccessToken != nil else { return }
-
-            try? await Task.sleep(for: .milliseconds(500))
-            guard !Task.isCancelled else { return }
-
-            await checkWebAccess()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .networkChanged)) { _ in
-            webAccessToken = UUID()
         }
         .sensoryAlert(
             isPresented: webhook.errorBinding,
@@ -224,14 +212,13 @@ struct InstanceView: View {
     var toolbarWebButton: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
             Button {
-                if let url = webAccessURL {
+                if let url = webAccessURL ?? URL(string: instance.url) {
                     openURL(url, prefersInApp: true)
                 }
             } label: {
                 Image(systemName: "safari")
             }
             .tint(.primary)
-            .disabled(webAccessURL == nil)
         }
     }
 

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -29,6 +29,7 @@ struct InstanceView: View {
     @State var diskSpaceExpanded: Bool = false
 
     @State var webAccessURL: URL?
+    @State var webAccessToken: UUID?
 
     @Environment(AppSettings.self) var settings
     @Environment(RadarrInstance.self) var radarrInstance
@@ -76,6 +77,17 @@ struct InstanceView: View {
         }
         .onBecomeActive {
             await setup()
+        }
+        .task(id: webAccessToken) {
+            guard webAccessToken != nil else { return }
+
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+
+            await checkWebAccess()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .networkChanged)) { _ in
+            webAccessToken = UUID()
         }
         .sensoryAlert(
             isPresented: webhook.errorBinding,

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -28,6 +28,8 @@ struct InstanceView: View {
     @State var diskSpaceState: MetadataState<[InstanceDiskSpace]> = .idle
     @State var diskSpaceExpanded: Bool = false
 
+    @State var webAccessURL: URL?
+
     @Environment(AppSettings.self) var settings
     @Environment(RadarrInstance.self) var radarrInstance
     @Environment(SonarrInstance.self) var sonarrInstance
@@ -92,12 +94,14 @@ struct InstanceView: View {
 
     func setup() async {
         async let summary: Void = loadSummary()
+        async let webAccess: Void = checkWebAccess()
 
         await setAppNotificationsStatus()
         await setCloudKitAccountStatus()
         await setSubscriptionStatus()
         await initialWebhookSync()
         await summary
+        await webAccess
     }
 
     var instanceDetails: some View {
@@ -208,16 +212,19 @@ struct InstanceView: View {
     var toolbarWebButton: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
             Button {
-                Task {
-                    if let url = await instance.webURL() {
-                        openURL(url, prefersInApp: true)
-                    }
+                if let url = webAccessURL {
+                    openURL(url, prefersInApp: true)
                 }
             } label: {
                 Image(systemName: "safari")
             }
             .tint(.primary)
+            .disabled(webAccessURL == nil)
         }
+    }
+
+    func checkWebAccess() async {
+        webAccessURL = await instance.reachableWebURL()
     }
 
     @ToolbarContentBuilder


### PR DESCRIPTION
## Summary

Adds a `reachableWebURL(for:)` method to `InstanceResolver` that determines which instance URL is actually reachable from a browser, accounting for the fact that Safari may hold session cookies the app cannot see. The web access button in the instance settings view uses it to pick the best URL to open — best-effort: if the check hasn't finished or nothing answered, the button falls back to the primary URL, so it is never disabled.

## Key Changes

- **InstanceResolver**:
  - Added `reachableWebURL(for:)`, which checks each candidate URL unauthenticated (no API key, no custom headers, no cookies) to determine browser reachability
  - Introduced a `WebVerdict` classification: `verified` (genuine Radarr/Sonarr `/ping` response), `answered` (any response — a redirect, a 403, a login page), or `dead` (no response)
  - Redirects are never followed (a task delegate returns the origin's 3xx as the answer), so a candidate is judged only by the host that was actually asked — never by whether some host further down a redirect chain is up
  - Checks run on an ephemeral 5-second-timeout session so nothing cached can make a dead URL look alive
  - Refactored `currentSelection(for:)` on top of a new `rankedCandidates(for:)` helper, which the web check uses to walk candidates best-first

- **InstanceView**:
  - Caches the reachable URL in `webAccessURL` state, resolved during `setup()` (initial appearance and foreground resume)
  - The toolbar web button opens the cached URL, falling back to the primary URL when no verdict is available — the check picks a better URL when it can, it never gates the button

- **Instance**:
  - Renamed `webURL()` to `reachableWebURL()`, delegating to `InstanceResolver.shared.reachableWebURL(for:)`

## Implementation Details

The browser-aware check is necessary because Safari maintains its own session cookies outside the app container, which `URLSession` cannot access. A host that rejects the app's unauthenticated request may still serve the browser a valid page via an existing session. The implementation therefore:

1. Checks candidates in ranked order (best first)
2. Returns immediately on a verified response (genuine Radarr/Sonarr `/ping`) — at home the LAN URL wins outright and the remote is never contacted
3. Falls back to any host that answered (even with a 403 or redirect) rather than one that didn't respond
4. Treats the check as advisory: a wrong or slow verdict costs opening a worse URL, never a locked-out button

https://claude.ai/code/session_01Cc773AT1gMniuRGwwwbbTK
