### PR TITLE
Respect Safari's session on the web check, deduplicate the ping plumbing

### DIFF
--- a/Ruddarr/Services/InstanceResolver.swift
+++ b/Ruddarr/Services/InstanceResolver.swift
@@ -26,10 +26,11 @@ import Foundation
 ///   which demotes that base for the current network and returns the instance's next-best one.
 /// - Browser-aware: `reachableWebURL(for:)` answers a different question — which URL a *browser*
 ///   can open — by checking every candidate unauthenticated, so the app's own credentials and
-///   headers can't vouch for a URL Safari would be turned away from. Reachable means pingable:
-///   only a genuine `/ping` counts, and when no candidate answers one the web button is
-///   disabled rather than pointed at a URL that would fail to load. These verdicts are cached
-///   separately from the routing probes and never feed ranking.
+///   headers can't vouch for a URL Safari would be turned away from. Safari's own cookies are
+///   outside the app container and unreadable, so a host that answers *anything* stays worth
+///   opening; only when nothing answers anywhere is the web button disabled rather than pointed
+///   at a URL that would fail to load. These verdicts are cached separately from the routing
+///   probes and never feed ranking.
 ///
 /// The resolved URL is purely runtime state and is never persisted, so it can never reach
 /// iCloud, the App Group, or another device.
@@ -122,14 +123,15 @@ actor InstanceResolver {
         ResolverRouting.noteSuccess(&state, for: url.absoluteString, candidates: candidates)
     }
 
-    /// The instance's web interface at a URL a browser can actually open, or `nil` when none of
-    /// its candidates is reachable — which is what disables the web button in `InstanceView`.
-    /// Selection alone can't answer this: it knows which address the *app* should talk to,
-    /// having authenticated, and says nothing about what a browser would get there.
+    /// The instance's web interface at a URL worth handing to a browser, or `nil` when nothing
+    /// answered anywhere — which is what disables the web button in `InstanceView`. Selection
+    /// alone can't answer this: it knows which address the *app* should talk to, having
+    /// authenticated, and says nothing about what a browser would get there.
     ///
-    /// Reachable means *pingable*. Only a genuine Radarr/Sonarr `/ping` counts, so a candidate
-    /// that merely answers — a redirect to an identity provider, a 403, a login page — is never
-    /// offered: the button is handed a URL that demonstrably serves the interface, or none.
+    /// A verified candidate — a genuine Radarr/Sonarr `/ping` — wins over one that merely
+    /// answered, but an answering host (a redirect to an identity provider, a 403, a login
+    /// page) is never written off: Safari may hold a session this check cannot see and walk
+    /// straight in. Only a candidate nothing can reach is treated as unreachable.
     ///
     /// Every candidate is checked rather than stopping at the first hit, so the diagnostics
     /// screen can show a verdict for each one; the checks run concurrently and at most once per
@@ -142,7 +144,7 @@ actor InstanceResolver {
         if !pending.isEmpty {
             let outcomes = await withTaskGroup(of: (String, ProbeOutcome).self) { group in
                 for base in pending {
-                    group.addTask { (base, await Self.webCheck(base)) }
+                    group.addTask { (base, await Self.probe(base, via: webCheckSession)) }
                 }
 
                 var results: [(String, ProbeOutcome)] = []
@@ -157,43 +159,8 @@ actor InstanceResolver {
             }
         }
 
-        for base in candidates where state.webOutcomes[base]?.reachable == true {
-            if let url = URL(string: base) { return url }
-        }
-
-        return nil
-    }
-
-    /// One candidate's browser-facing check: an unauthenticated `GET {base}/ping` — no API key,
-    /// no custom headers, no stored cookies — so the instance's own credentials can't vouch for
-    /// an address a browser would be turned away from. Judged by exactly the verdict the routing
-    /// probe uses: HTTP success, from the host that was asked, carrying `{"status": "OK"}`.
-    /// Redirects are never followed, so the answer is the origin's own and can't turn on whether
-    /// some host further down a chain happens to be up.
-    private static func webCheck(_ base: String) async -> ProbeOutcome {
-        guard let url = ResolverRouting.probeURL(for: base) else {
-            return ProbeOutcome(reachable: false)
-        }
-
-        let clock = ContinuousClock()
-        let started = clock.now
-
-        guard let (data, response) = try? await webCheckSession.data(from: url),
-              let http = response as? HTTPURLResponse,
-              ResolverRouting.probeVerdict(
-                  status: http.statusCode,
-                  finalHost: http.url?.host(percentEncoded: false),
-                  probedHost: url.host(percentEncoded: false),
-                  body: data
-              )
-        else {
-            return ProbeOutcome(reachable: false)
-        }
-
-        let elapsed = started.duration(to: clock.now)
-        let latency = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
-
-        return ProbeOutcome(reachable: true, latency: latency)
+        return ResolverRouting.webSelection(candidates, outcomes: state.webOutcomes)
+            .flatMap { URL(string: $0) }
     }
 
     /// Hands the origin's redirect back as the task's response instead of following it, so a
@@ -210,8 +177,9 @@ actor InstanceResolver {
     }
 
     /// Ephemeral (no cookies, no cache) so nothing stored can make a dead URL look alive, and
-    /// more patient than the routing probe: a candidate wrongly called dead takes the web button
-    /// down with it, so a slow remote host is given room to answer.
+    /// more patient than the routing probe: a candidate wrongly called dead is passed over for
+    /// a worse one — or, when nothing else answers, takes the web button down with it — so a
+    /// slow remote host is given room to answer.
     private static let webCheckSession: URLSession = {
         let timeout: TimeInterval = 5
 
@@ -333,7 +301,7 @@ actor InstanceResolver {
 
         for base in bases {
             Task(priority: .utility) {
-                let outcome = await Self.probe(base)
+                let outcome = await Self.probe(base, via: probeSession)
                 recordProbe(base: base, epoch: epoch, outcome: outcome)
             }
         }
@@ -354,7 +322,13 @@ actor InstanceResolver {
         return URLSession(configuration: configuration)
     }()
 
-    private static func probe(_ base: String) async -> ProbeOutcome {
+    /// One candidate's `/ping`, timed — unauthenticated by design (no API key, no custom
+    /// headers, no stored cookies), which is what both callers need: the routing probe because
+    /// no secret may ride along to an unverified address, the web check because the instance's
+    /// own credentials can't vouch for an address a browser would be turned away from.
+    /// `reachable` carries the strict verdict (HTTP success, from the host that was asked,
+    /// carrying `{"status": "OK"}`); `answered` records that any response came back at all.
+    private static func probe(_ base: String, via session: URLSession) async -> ProbeOutcome {
         guard let url = ResolverRouting.probeURL(for: base) else {
             return ProbeOutcome(reachable: false)
         }
@@ -362,14 +336,8 @@ actor InstanceResolver {
         let clock = ContinuousClock()
         let started = clock.now
 
-        guard let (data, response) = try? await probeSession.data(from: url),
-              let http = response as? HTTPURLResponse,
-              ResolverRouting.probeVerdict(
-                  status: http.statusCode,
-                  finalHost: http.url?.host(percentEncoded: false),
-                  probedHost: url.host(percentEncoded: false),
-                  body: data
-              )
+        guard let (data, response) = try? await session.data(from: url),
+              let http = response as? HTTPURLResponse
         else {
             return ProbeOutcome(reachable: false)
         }
@@ -377,7 +345,14 @@ actor InstanceResolver {
         let elapsed = started.duration(to: clock.now)
         let latency = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
 
-        return ProbeOutcome(reachable: true, latency: latency)
+        let verified = ResolverRouting.probeVerdict(
+            status: http.statusCode,
+            finalHost: http.url?.host(percentEncoded: false),
+            probedHost: url.host(percentEncoded: false),
+            body: data
+        )
+
+        return ProbeOutcome(reachable: verified, answered: true, latency: verified ? latency : nil)
     }
 
     private func dispatchResolution(_ hosts: [String], snapshot: NetworkSnapshot, epoch: Int) {

--- a/Ruddarr/Services/NetworkSnapshot.swift
+++ b/Ruddarr/Services/NetworkSnapshot.swift
@@ -50,12 +50,16 @@ struct ResolvedHost: Equatable {
     var addresses: [String] = []
 }
 
-/// The verdict of a background `/ping` probe of an off-link private candidate — a server that
-/// may sit on a sibling VLAN behind the same router. `reachable` means the address answered
-/// with a genuine Radarr/Sonarr ping response on the *current* network; like every resolver
-/// cache it is scoped to the network fingerprint and never persisted.
+/// The verdict of a background `/ping` check — the routing probe of an off-link private
+/// candidate, or the browser-facing web check of any candidate. `reachable` means the address
+/// answered with a genuine Radarr/Sonarr ping response on the *current* network; `answered`
+/// records the weaker fact that *some* HTTP response came back — a redirect, a 403, a login
+/// page. Routing reads `reachable` alone; the web check also reads `answered`, because Safari
+/// may hold a session the app cannot see, so an answering host stays worth opening. Like every
+/// resolver cache these are scoped to the network fingerprint and never persisted.
 struct ProbeOutcome: Equatable, Sendable {
     var reachable: Bool
+    var answered: Bool = false
     var latency: TimeInterval?
 }
 

--- a/Ruddarr/Services/ResolverRouting.swift
+++ b/Ruddarr/Services/ResolverRouting.swift
@@ -358,6 +358,22 @@ enum ResolverRouting {
         state.webOutcomes[base] = outcome
     }
 
+    /// The candidate the web button should open, from cached web verdicts alone: the best-ranked
+    /// verified base, else the best-ranked one that answered at all — Safari may hold a session
+    /// the unauthenticated check cannot see, so an answering host is never written off — else
+    /// `nil`, which is what disables the button. `candidates` must already be in ranked order.
+    static func webSelection(_ candidates: [String], outcomes: [String: ProbeOutcome]) -> String? {
+        var answered: String?
+
+        for base in candidates {
+            guard let outcome = outcomes[base] else { continue }
+            if outcome.reachable { return base }
+            if answered == nil && outcome.answered { answered = base }
+        }
+
+        return answered
+    }
+
     /// The unauthenticated `{base}/ping` endpoint (Radarr and Sonarr both serve it), with any
     /// inline credentials stripped — no secret ever rides along to an address that isn't
     /// verified yet.

--- a/Ruddarr/Utilities/NetworkReport.swift
+++ b/Ruddarr/Utilities/NetworkReport.swift
@@ -27,20 +27,24 @@ struct NetworkReport: Equatable, Sendable {
         }
 
         var probeDescription: String? {
-            guard let probe else { return nil }
-            guard probe.reachable else { return "unreachable" }
-            guard let latency = probe.latency else { return "reachable" }
-
-            return "reachable (\(Int((latency * 1_000).rounded())) ms)"
+            Self.outcomeDescription(probe)
         }
 
-        /// The browser-facing verdict: whether this candidate answered a `/ping` unauthenticated,
-        /// and so whether the web button may hand it to Safari. `nil` until the check has run on
-        /// this network — distinct from a check that ran and found nothing.
+        /// The browser-facing verdict: whether the web button may hand this candidate to Safari.
+        /// "answered" is a host that responded without proving it serves the interface — still
+        /// openable, since Safari may hold a session the check cannot see. `nil` until the check
+        /// has run on this network — distinct from a check that ran and found nothing.
         var webDescription: String? {
             guard let web else { return nil }
-            guard web.reachable else { return "unreachable" }
-            guard let latency = web.latency else { return "reachable" }
+            if web.answered && !web.reachable { return "answered" }
+
+            return Self.outcomeDescription(web)
+        }
+
+        private static func outcomeDescription(_ outcome: ProbeOutcome?) -> String? {
+            guard let outcome else { return nil }
+            guard outcome.reachable else { return "unreachable" }
+            guard let latency = outcome.latency else { return "reachable" }
 
             return "reachable (\(Int((latency * 1_000).rounded())) ms)"
         }

--- a/Ruddarr/Views/Settings/DiagnosticsView.swift
+++ b/Ruddarr/Views/Settings/DiagnosticsView.swift
@@ -279,8 +279,10 @@ struct DiagnosticsView: View {
             failedRequests = failures
         }
 
+        // Fire-and-forget: verdicts land in the resolver's cache and the next two-second tick
+        // renders them, so a dead host's timeout can never stall this refresh loop.
         for instance in instances {
-            _ = await InstanceResolver.shared.reachableWebURL(for: instance)
+            Task { _ = await InstanceResolver.shared.reachableWebURL(for: instance) }
         }
     }
 

--- a/Ruddarr/Views/Settings/DiagnosticsView.swift
+++ b/Ruddarr/Views/Settings/DiagnosticsView.swift
@@ -165,11 +165,11 @@ struct DiagnosticsView: View {
                     }
 
                     if candidate.probeDescription != nil {
-                        networkDiagnosticsRow("Probe", probeText(candidate))
+                        networkDiagnosticsRow("Probe", outcomeText(candidate.probeDescription, reachable: candidate.probe?.reachable == true))
                     }
 
                     if candidate.webDescription != nil {
-                        networkDiagnosticsRow("Web", webText(candidate))
+                        networkDiagnosticsRow("Web", outcomeText(candidate.webDescription, reachable: candidate.web?.reachable == true))
                     }
                 } label: {
                     HStack(spacing: 5) {
@@ -253,16 +253,9 @@ struct DiagnosticsView: View {
         return Text(value)
     }
 
-    func probeText(_ candidate: NetworkReport.Candidate) -> Text {
-        var value = AttributedString(candidate.probeDescription ?? "")
-        value.foregroundColor = candidate.probe?.reachable == true ? .green : .orange
-
-        return Text(value)
-    }
-
-    func webText(_ candidate: NetworkReport.Candidate) -> Text {
-        var value = AttributedString(candidate.webDescription ?? "")
-        value.foregroundColor = candidate.web?.reachable == true ? .green : .orange
+    func outcomeText(_ description: String?, reachable: Bool) -> Text {
+        var value = AttributedString(description ?? "")
+        value.foregroundColor = reachable ? .green : .orange
 
         return Text(value)
     }

--- a/Ruddarr/Views/Settings/InstanceView.swift
+++ b/Ruddarr/Views/Settings/InstanceView.swift
@@ -29,6 +29,7 @@ struct InstanceView: View {
     @State var diskSpaceExpanded: Bool = false
 
     @State var webAccessState: MetadataState<URL> = .idle
+    @State var networkToken: UUID?
 
     @Environment(AppSettings.self) var settings
     @Environment(RadarrInstance.self) var radarrInstance
@@ -71,11 +72,22 @@ struct InstanceView: View {
         .task {
             await setup()
         }
+        .task(id: networkToken) {
+            guard networkToken != nil else { return }
+
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+
+            await checkWebAccess()
+        }
         .onChange(of: instanceNotifications) {
             Task { await notificationsToggled() }
         }
         .onBecomeActive {
             await setup()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .networkChanged)) { _ in
+            networkToken = UUID()
         }
         .sensoryAlert(
             isPresented: webhook.errorBinding,
@@ -233,7 +245,13 @@ struct InstanceView: View {
     func checkWebAccess() async {
         webAccessState = .loading
 
-        if let url = await instance.reachableWebURL() {
+        let url = await instance.reachableWebURL()
+
+        // A superseded re-check (the network flapped again mid-flight) must not overwrite
+        // the verdict the fresher task is about to write.
+        guard !Task.isCancelled else { return }
+
+        if let url {
             webAccessState = .loaded(url)
         } else {
             webAccessState = .failed

--- a/Tests/ResolverProbeTests.swift
+++ b/Tests/ResolverProbeTests.swift
@@ -323,4 +323,29 @@ struct ResolverProbeTests {
         let ordered = ResolverRouting.rank(&state, candidates: [remote, routed], snapshot: home, fingerprint: home.fingerprint, now: t0)
         #expect(ordered == [remote, routed])
     }
+
+    @Test func webSelectionPrefersVerifiedOverAnswered() {
+        let verdicts = [
+            remote: ProbeOutcome(reachable: false, answered: true),
+            routed: ProbeOutcome(reachable: true, latency: 0.01),
+        ]
+
+        // A genuine `/ping` outranks a mere answer, even from a better-ranked candidate.
+        #expect(ResolverRouting.webSelection([remote, routed], outcomes: verdicts) == routed)
+    }
+
+    @Test func webSelectionKeepsAnsweredHostsOpenable() {
+        // Safari may hold a session the unauthenticated check cannot see, so a host that
+        // answered — a 403, a login page, an identity-provider redirect — is still offered.
+        let verdicts = [
+            remote: ProbeOutcome(reachable: false, answered: true),
+            routed: ProbeOutcome(reachable: false),
+        ]
+
+        #expect(ResolverRouting.webSelection([routed, remote], outcomes: verdicts) == remote)
+
+        // Only when nothing answers anywhere is there no URL — the disabled web button.
+        #expect(ResolverRouting.webSelection([routed], outcomes: [routed: ProbeOutcome(reachable: false)]) == nil)
+        #expect(ResolverRouting.webSelection([remote], outcomes: [:]) == nil)
+    }
 }


### PR DESCRIPTION
Stacked on #775. Softens its reachability rule and removes the code it duplicated.

A host that answers anything — a redirect to an identity provider, a 403, a
login page — is offered to the browser again: Safari may hold a session the
unauthenticated check cannot see, so only a candidate nothing can reach is
treated as unreachable, and the button disables only when no candidate
answers at all. A verified `/ping` still wins over a mere answer, and the
selection rule lives in `ResolverRouting.webSelection`, where it is tested.
Diagnostics shows "answered" as its own verdict.

The web check and the routing probe collapse into one timed ping
parameterized by session, with `ProbeOutcome` recording the weaker
"answered" fact alongside the strict verdict; the duplicated description
and row-color helpers merge into one each.

The diagnostics refresh loop fires web checks without awaiting them —
verdicts land in the resolver's cache and the next two-second tick renders
them, so a dead host's timeout can no longer stall the screen. The instance
view re-runs its check when the network changes, on the same debounced
`networkToken` idiom `InstanceRow` already uses; a superseded in-flight
re-check is dropped instead of overwriting the fresher verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6JTQmbdBVTUdDmS5TUoWT