### PR TITLE
Do nothing when a deeplink targets what's already on screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ Guidance for AI agents working in this repository.
 
 ## Local instances
 
-- To see which local Radarr and Sonarr instances are available for development, inspect `Ruddarr/seed-instances.json`. This file is git-ignored because it contains private URLs, API keys, and potentially authentication headers; never commit or expose its contents.
-- To configure it, copy `Ruddarr/Preview Content/seed-instances.example.json` to `Ruddarr/seed-instances.json` and replace the example values.
+- To see which local Radarr and Sonarr instances are available for development, inspect `Ruddarr/Preview Content/seed-instances.json`. This file is git-ignored because it contains private URLs, API keys, and potentially authentication headers; never commit or expose its contents.
+- To configure it, copy `Ruddarr/Preview Content/seed-instances.example.json` to `Ruddarr/Preview Content/seed-instances.json` and replace the example values.
 - In a debug build, open Settings and use **Seed Instances** in the Instances section to load or update the configured instances.
 
 ## Build and test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed redundant network requests when opening views and at launch
 - Fixed calendar day highlight not updating at midnight
 - Fixed activity tab hiding tasks when many seasons are downloading
+- Fixed deeplinks reloading the movie, series or season already on screen
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/Ruddarr/Dependencies/QuickActions.swift
+++ b/Ruddarr/Dependencies/QuickActions.swift
@@ -57,6 +57,12 @@ final class QuickActions {
     }
 
     func openMovie(_ id: Movie.ID, _ instance: String?) {
+        if dependencies.router.moviesPath == [.movie(id)], staysOnInstance(instance, AppSettings.shared.radarrInstanceId) {
+            dependencies.router.selectedTab = .movies
+
+            return
+        }
+
         dependencies.router.switchToRadarrInstance = instance
         dependencies.router.selectedTab = .movies
         dependencies.router.moviesPath = .init()
@@ -86,6 +92,12 @@ final class QuickActions {
     }
 
     func openSeries(_ id: Series.ID, _ season: Season.ID?, _ episode: Episode.ID?, _ instance: String?) {
+        if episode == nil, isShowing(id, season), staysOnInstance(instance, AppSettings.shared.sonarrInstanceId) {
+            dependencies.router.selectedTab = .series
+
+            return
+        }
+
         dependencies.router.switchToSonarrInstance = instance
         dependencies.router.selectedTab = .series
         dependencies.router.seriesPath = .init()
@@ -101,6 +113,22 @@ final class QuickActions {
                 }
             }
         }
+    }
+
+    private func isShowing(_ id: Series.ID, _ season: Season.ID?) -> Bool {
+        guard let season else {
+            return dependencies.router.seriesPath == [.series(id)]
+        }
+
+        return dependencies.router.seriesPath == [.series(id), .season(id, season)]
+    }
+
+    private func staysOnInstance(_ requested: String?, _ selected: Instance.ID?) -> Bool {
+        guard let instance = AppSettings.shared.instanceBy(requested) else {
+            return true
+        }
+
+        return instance.id == selected
     }
 
     func clearTimer() {

--- a/Ruddarr/Dependencies/Router.swift
+++ b/Ruddarr/Dependencies/Router.swift
@@ -11,8 +11,8 @@ final class Router {
     var switchToRadarrInstance: String?
     var switchToSonarrInstance: String?
 
-    var moviesPath: NavigationPath = .init()
-    var seriesPath: NavigationPath = .init()
+    var moviesPath: [MoviesPath] = .init()
+    var seriesPath: [SeriesPath] = .init()
     var calendarPath: NavigationPath = .init()
     var settingsPath: NavigationPath = .init()
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -50,6 +50,7 @@ Fixed
 - Fixed redundant network requests when opening views and at launch
 - Fixed calendar day highlight not updating at midnight
 - Fixed activity tab hiding tasks when many seasons are downloading
+- Fixed deeplinks reloading the movie, series or season already on screen
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
Opening a deeplink for the movie, series or season you're already looking at reset the navigation stack to its root and then pushed the same destination back on, so you saw a pop-then-push flicker and the detail view was torn down and rebuilt (refetching files, history, etc.).

This shows up most from notification taps, Spotlight results, and the in-app queue/calendar sheets, all of which route through `QuickActions.Deeplink`.

## The change

`QuickActions.openMovie` / `openSeries` now return early when the current path already matches the request, before the `= .init()` that causes the pop. The tab is still switched, since a deeplink can arrive while you're on Activity or Calendar.

Reading the current path is the only structural obstacle: `NavigationPath` is write-only, so `Router.moviesPath` and `seriesPath` become `[MoviesPath]` / `[SeriesPath]`. `NavigationStack(path:)` takes a typed collection binding just as happily, and `append`/`removeLast`/`isEmpty`/`.init()`/`.init([x])` are identical on `Array` — so the two declarations are the whole diff there. I checked all ~30 push sites and every `NavigationLink(value:)` reachable from these two stacks; all of them already use the matching concrete type, including `InformationItem.link`, which is typed `any Hashable` but is only ever handed a `MoviesPath.edit`/`SeriesPath.edit`. `calendarPath` and `settingsPath` stay `NavigationPath`, and the calendar sheets keep their own local paths.

## Scope

Deliberately minimal — two files, ~30 lines, no view changes:

- **Exact match, not prefix.** Deeplinking to a movie while you're on its releases screen still pops back one level, exactly as before. Only the true "already exactly here" case becomes a no-op, which is the case that actually fires in practice.
- **Episode deeplinks are untouched.** `SeriesPath.episode` holds Sonarr's internal episode id while the deeplink carries the episode *number*; `SeriesView.resolveEpisode` converts between them asynchronously and needs the instance, which `QuickActions` can't reach. Matching on the season alone would wrongly no-op when you deeplink to a different episode of the same season, so `openEpisode` just falls through to the existing behavior.
- An unresolvable instance name counts as "stays put", matching what `maybeSwitchToInstance` already does with one.

## Testing

Not built or run — this session is a Linux container with no Swift toolchain, so the Xcode project can't be compiled here. The Array-for-`NavigationPath` swap in particular is API-compatible at every call site I audited, but it wants a real compile and a device check before merging. Worth exercising by hand: a notification tap for the movie already open, the same for a season, and a deeplink to a *different* episode of the season you're viewing (must still navigate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZRHS1d9GZzjPzqFjTktSt)_