### PR TITLE
Lighten custom format tags in detailed releases list in dark mode

### DIFF
--- a/Ruddarr/Utilities/Colors.swift
+++ b/Ruddarr/Utilities/Colors.swift
@@ -19,6 +19,7 @@ extension ShapeStyle where Self == Color {
 
 #if os(iOS)
     static var card: Color { .quaternarySystemFill }
+    static var elevatedCard: Color { .tertiarySystemFill }
     static var label: Color { Color(UIColor.label) }
 
     static var darkGray: Color { Color(UIColor.darkGray) }
@@ -42,6 +43,7 @@ extension ShapeStyle where Self == Color {
     static var buttonFill: Color { Color(UIColor.systemGray5) }
 #else
     static var card: Color { .tertiarySystemFill }
+    static var elevatedCard: Color { .secondarySystemFill }
     static var label: Color { Color(NSColor.labelColor) }
 
     static var darkGray: Color { Color(NSColor.darkGray) }

--- a/Ruddarr/Views/Shared/CustomFormat.swift
+++ b/Ruddarr/Views/Shared/CustomFormat.swift
@@ -47,7 +47,9 @@ struct CustomFormat: View {
             .padding(.vertical, small ? 3 : 4)
             .padding(.horizontal, small ? 6 : 8)
             .background(
-                RoundedRectangle(cornerRadius: small ? 3.5 : 4).fill(.card)
+                RoundedRectangle(cornerRadius: small ? 3.5 : 4).fill(
+                    small && colorScheme == .dark ? .elevatedCard : .card
+                )
             )
     }
 }


### PR DESCRIPTION
The tags in the detailed releases layout sit on the plain list
background, where `.card` (quaternary system fill) is nearly
indistinguishable from black in dark mode.

Use one step up the system fill ladder for the small tag variant in
dark mode. The sheets keep `.card`, since they already draw on an
elevated background.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwwGeSMRyE57pVFyEj68tE