### PR TITLE
Update lookup caches after adding movies or series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed calendar day highlight not updating at midnight
 - Fixed activity tab hiding tasks when many seasons are downloading
 - Fixed deeplinks reloading the movie, series or season already on screen
+- Fixed search results not updating after adding a movie or series
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/Ruddarr/Models/Movies/MovieLookup.swift
+++ b/Ruddarr/Models/Movies/MovieLookup.swift
@@ -108,7 +108,6 @@ class MovieLookup {
         return queries[query] ?? nil
     }
 
-    // replace stale lookup records, e.g. after adding a movie to the library
     func updateItem(_ movie: Movie) {
         if let index = items?.firstIndex(where: { $0.tmdbId == movie.tmdbId }) {
             items?[index] = movie

--- a/Ruddarr/Models/Movies/MovieLookup.swift
+++ b/Ruddarr/Models/Movies/MovieLookup.swift
@@ -108,6 +108,15 @@ class MovieLookup {
         return queries[query] ?? nil
     }
 
+    // replace stale lookup records, e.g. after adding a movie to the library
+    func updateItem(_ movie: Movie) {
+        if let index = items?.firstIndex(where: { $0.tmdbId == movie.tmdbId }) {
+            items?[index] = movie
+        }
+
+        queries["tmdb:\(movie.tmdbId)"] = movie
+    }
+
     // consider caching this for performance
     var sortedItems: [Movie] {
         let items = items ?? []

--- a/Ruddarr/Models/Series/SeriesLookup.swift
+++ b/Ruddarr/Models/Series/SeriesLookup.swift
@@ -108,6 +108,17 @@ class SeriesLookup {
         return queries[query] ?? nil
     }
 
+    // replace stale lookup records, e.g. after adding a series to the library
+    func updateItem(_ series: Series) {
+        if let index = items?.firstIndex(where: { $0.tvdbId == series.tvdbId }) {
+            items?[index] = series
+        }
+
+        if let tmdbId = series.tmdbId {
+            queries["tmdb:\(tmdbId)"] = series
+        }
+    }
+
     // consider caching this for performance
     var sortedItems: [Series] {
         let items = items ?? []

--- a/Ruddarr/Models/Series/SeriesLookup.swift
+++ b/Ruddarr/Models/Series/SeriesLookup.swift
@@ -108,7 +108,6 @@ class SeriesLookup {
         return queries[query] ?? nil
     }
 
-    // replace stale lookup records, e.g. after adding a series to the library
     func updateItem(_ series: Series) {
         if let index = items?.firstIndex(where: { $0.tvdbId == series.tvdbId }) {
             items?[index] = series

--- a/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
+++ b/Ruddarr/Views/Movies/Search/MoviePreviewView.swift
@@ -107,6 +107,8 @@ struct MoviePreviewView: View {
             fatalError("Failed to locate added movie by TMDB id")
         }
 
+        instance.lookup.updateItem(addedMovie)
+
         #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         #endif

--- a/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
+++ b/Ruddarr/Views/Series/Search/SeriesPreviewView.swift
@@ -108,6 +108,8 @@ struct SeriesPreviewView: View {
             fatalError("Failed to locate added series by TVDB id")
         }
 
+        instance.lookup.updateItem(addedSeries)
+
         #if os(iOS)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         #endif

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -51,6 +51,7 @@ Fixed
 - Fixed calendar day highlight not updating at midnight
 - Fixed activity tab hiding tasks when many seasons are downloading
 - Fixed deeplinks reloading the movie, series or season already on screen
+- Fixed search results not updating after adding a movie or series
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
## Summary
Fixes search results not updating after adding a movie or series to the library by refreshing the lookup cache with the newly added item.

## Changes
- Added `updateItem(_:)` method to `SeriesLookup` to replace stale lookup records by TVDB ID and update the TMDB query cache
- Added `updateItem(_:)` method to `MovieLookup` to replace stale lookup records by TMDB ID and update the query cache
- Call `lookup.updateItem()` in `MoviePreviewView` after successfully adding a movie
- Call `lookup.updateItem()` in `SeriesPreviewView` after successfully adding a series
- Updated `CHANGELOG.md` and `TestFlight/WhatToTest.en-US.txt` with the fix

## Implementation Details
The lookup cache is now synchronized immediately after an item is added to the library, ensuring that subsequent searches reflect the updated state (e.g., showing the item as already in the library rather than available for import).

https://claude.ai/code/session_01XUrp78Rz5t1VLDnGsEvvH6