### PR TITLE
Check full library for discovery grid membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed search results not updating after adding media
 - Fixed home tab preference being ignored on macOS
 - Fixed release search briefly showing an empty state after searching
+- Fixed discovery grid ignoring library items excluded by active filters
 
 ### Removed
 - Dropped support for Sonarr v3

--- a/Ruddarr/Services/Discovery.swift
+++ b/Ruddarr/Services/Discovery.swift
@@ -108,12 +108,12 @@ struct DiscoveryItem: Identifiable, Codable, Equatable {
     @MainActor
     func libraryMovie(in instance: RadarrInstance) -> Movie? {
         guard type == .movie else { return nil }
-        return instance.movies.cachedItems.first { $0.tmdbId == id }
+        return instance.movies.items.first { $0.tmdbId == id }
     }
 
     @MainActor
     func librarySeries(in instance: SonarrInstance) -> Series? {
         guard type == .series else { return nil }
-        return instance.series.cachedItems.first { $0.tmdbId == id }
+        return instance.series.items.first { $0.tmdbId == id }
     }
 }

--- a/Ruddarr/Views/Shared/MediaGrid+Content.swift
+++ b/Ruddarr/Views/Shared/MediaGrid+Content.swift
@@ -163,7 +163,7 @@ struct DiscoveryGridPoster: View {
             return
         }
 
-        if !sonarrInstance.series.cachedItems.contains(where: { $0.tmdbId != nil }) {
+        if !sonarrInstance.series.items.contains(where: { $0.tmdbId != nil }) {
             self.error = API.Error(from: AppError.upgradeRequired(.sonarr, to: "4.0.5"))
 
             return

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -54,6 +54,7 @@ Fixed
 - Fixed search results not updating after adding media
 - Fixed home tab preference being ignored on macOS
 - Fixed release search briefly showing an empty state after searching
+- Fixed discovery grid ignoring library items excluded by active filters
 
 Removed
 - Dropped support for Sonarr v3


### PR DESCRIPTION
## Summary
Follow-up to #781. The discovery grid ("Popular This Week") resolved library membership against `cachedItems`, which is the library screen's *filtered and searched* list. With an active library filter or search query, an item that is in the library could be excluded from `cachedItems` and treated as missing by the discovery grid: the poster wasn't faded, showed no status overlay, and tapping it opened the add-preview flow instead of the library item.

## Changes
- `DiscoveryItem.libraryMovie(in:)` and `librarySeries(in:)` now search the unfiltered `items` list instead of `cachedItems`
- The Sonarr 4.0.5 version check in `DiscoveryGridPoster.navigateTo(series:)` sits on the same tap path and had the same flaw (an active filter could make it wrongly report "upgrade required"); it now also checks `items`
- Updated `CHANGELOG.md` and `TestFlight/WhatToTest.en-US.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUrp78Rz5t1VLDnGsEvvH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUrp78Rz5t1VLDnGsEvvH6)_