### PR TITLE
Remove deleted tasks from the queue immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fixed deleted tasks remaining in the queue until the next refresh
 
 ## 2.0.0 - 2026-08-12
 ### Added

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -23,6 +23,8 @@ class Queue {
     var items: [Instance.ID: [QueueItem]] = [:]
     var itemsWithIssues: Int = 0
 
+    private var revision: Int = 0
+
     let statuses = CurrentValueSubject<[QueueKey: QueueItemStatus], Never>([:])
     private(set) var active: [QueueItem] = []
 
@@ -50,6 +52,8 @@ class Queue {
         error = nil
         isLoading = true
 
+        let fetchRevision = revision
+
         await withThrowingTaskGroup(of: (Instance.ID, [QueueItem]).self) { group in
             for instance in instances {
                 group.addTask {
@@ -60,7 +64,9 @@ class Queue {
             while let result = await group.nextResult() {
                 switch result {
                 case .success(let (instanceId, records)):
-                    items[instanceId] = records
+                    if fetchRevision == revision {
+                        items[instanceId] = records
+                    }
                 case .failure(is CancellationError):
                     break
                 case .failure(let apiError as API.Error):
@@ -125,6 +131,15 @@ class Queue {
         }
 
         items[instanceId] = records
+
+        recomputeDerivedState()
+    }
+
+    func markDeleted(_ item: QueueItem) {
+        guard let instanceId = item.instanceId else { return }
+
+        revision += 1
+        items[instanceId]?.removeAll { $0.id == item.id }
 
         recomputeDerivedState()
     }

--- a/Ruddarr/Views/Activity/TaskRemovalView.swift
+++ b/Ruddarr/Views/Activity/TaskRemovalView.swift
@@ -100,6 +100,8 @@ struct TaskRemovalView: View {
         }
 
         if error == nil {
+            Queue.shared.markDeleted(item)
+
             await Queue.shared.fetchTasks()
         }
 

--- a/TestFlight/WhatToTest.en-US.txt
+++ b/TestFlight/WhatToTest.en-US.txt
@@ -1,1 +1,2 @@
-
+Fixed
+- Fixed deleted tasks remaining in the queue until the next refresh


### PR DESCRIPTION
Deleting a task called `fetchTasks()`, which bails out early when a poll
is already running, so the refresh was often skipped and the task stayed
in the list until the next poll. A poll that was already in flight could
also write the task back after it had been deleted.

Drop the task locally right after a successful delete, and discard fetch
results that were requested before items were changed locally.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011CCFUhYJ8Zo5NRxSfC1eWS