### PR TITLE
Namespace the API by app and drop redundant endpoint nouns

### DIFF
--- a/Ruddarr/Dependencies/API/API+Live.swift
+++ b/Ruddarr/Dependencies/API/API+Live.swift
@@ -8,26 +8,26 @@ extension API {
 
 extension RadarrAPI {
     static var live: Self {
-        .init(fetchMovies: { instance in
+        .init(fetch: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
 
             var movies: [Movie] = try await API.request(url: url, instance: instance, timeout: .slow)
             movies.stamp(instance.id)
             return movies
-        }, lookupMovies: { instance, query in
+        }, lookup: { instance, query in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie/lookup")
                 .appending(queryItems: [.init(name: "term", value: query)])
 
             return try await API.request(url: url, instance: instance, timeout: .sluggish)
-        }, lookupMovieReleases: { movieId, instance in
+        }, releases: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/release")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
             return try await API.request(url: url, instance: instance, timeout: .releaseSearch)
-        }, getMovie: { movieId, instance in
+        }, movie: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
                 .appending(path: String(movieId))
@@ -35,30 +35,30 @@ extension RadarrAPI {
             var movie: Movie = try await API.request(url: url, instance: instance)
             movie.stamp(instance.id)
             return movie
-        }, getMovieHistory: { movieId, instance in
+        }, history: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/history/movie")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
             return try await API.request(url: url, instance: instance)
-        }, getMovieFiles: { movieId, instance in
+        }, files: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/moviefile")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
             return try await API.request(url: url, instance: instance)
-        }, getMovieExtraFiles: { movieId, instance in
+        }, extraFiles: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/extrafile")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
             return try await API.request(url: url, instance: instance)
-        }, addMovie: { movie, instance in
+        }, add: { movie, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
 
             return try await API.request(method: .post, url: url, body: movie, instance: instance)
-        }, updateMovie: { movie, moveFiles, instance in
+        }, update: { movie, moveFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie/editor")
 
@@ -74,7 +74,7 @@ extension RadarrAPI {
             )
 
             return try await API.request(method: .put, url: url, body: body, instance: instance)
-        }, deleteMovie: { movie, addExclusion, deleteFildes, instance in
+        }, delete: { movie, addExclusion, deleteFildes, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
                 .appending(path: String(movie.id))
@@ -84,13 +84,13 @@ extension RadarrAPI {
                 ])
 
             return try await API.request(method: .delete, url: url, instance: instance)
-        }, deleteMovieFile: { file, instance in
+        }, deleteFile: { file, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/moviefile")
                 .appending(path: String(file.id))
 
             return try await API.request(method: .delete, url: url, instance: instance)
-        }, movieCalendar: { start, end, instance in
+        }, calendar: { start, end, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/calendar")
                 .appending(queryItems: [
@@ -108,14 +108,14 @@ extension RadarrAPI {
 
 extension SonarrAPI {
     static var live: Self {
-        .init(fetchSeries: { instance in
+        .init(fetch: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
 
             var series: [Series] = try await API.request(url: url, instance: instance, timeout: .slow)
             series.stamp(instance.id)
             return series
-        }, fetchEpisodes: { seriesId, instance in
+        }, episodes: { seriesId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/episode")
                 .appending(queryItems: [
@@ -126,13 +126,13 @@ extension SonarrAPI {
             var episodes: [Episode] = try await API.request(url: url, instance: instance)
             episodes.stamp(instance.id)
             return episodes
-        }, lookupSeries: { instance, query in
+        }, lookup: { instance, query in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series/lookup")
                 .appending(queryItems: [.init(name: "term", value: query)])
 
             return try await API.request(url: url, instance: instance, timeout: .sluggish)
-        }, lookupSeriesReleases: { seriesId, seasonId, episodeId, instance in
+        }, releases: { seriesId, seasonId, episodeId, instance in
             var url = try await instance.baseURL()
                 .appending(path: "/api/v3/release")
 
@@ -143,7 +143,7 @@ extension SonarrAPI {
             }
 
             return try await API.request(url: url, instance: instance, timeout: .releaseSearch)
-        }, getSeries: { seriesId, instance in
+        }, series: { seriesId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
                 .appending(path: String(seriesId))
@@ -151,18 +151,18 @@ extension SonarrAPI {
             var series: Series = try await API.request(url: url, instance: instance)
             series.stamp(instance.id)
             return series
-        }, addSeries: { series, instance in
+        }, add: { series, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
 
             return try await API.request(method: .post, url: url, body: series, instance: instance)
-        }, pushSeries: { series, instance in
+        }, push: { series, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
                 .appending(path: String(series.id))
 
             return try await API.request(method: .put, url: url, body: series, instance: instance)
-        }, updateSeries: { series, moveFiles, instance in
+        }, update: { series, moveFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series/editor")
 
@@ -180,7 +180,7 @@ extension SonarrAPI {
             )
 
             return try await API.request(method: .put, url: url, body: body, instance: instance)
-        }, deleteSeries: { series, addExclusion, deleteFiles, instance in
+        }, delete: { series, addExclusion, deleteFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
                 .appending(path: String(series.id))
@@ -197,7 +197,7 @@ extension SonarrAPI {
             let body = EpisodesMonitorResource(episodeIds: ids, monitored: monitored)
 
             return try await API.request(method: .put, url: url, body: body, instance: instance)
-        }, getEpisodeHistory: { id, instance in
+        }, episodeHistory: { id, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/history")
                 .appending(queryItems: [.init(name: "episodeId", value: String(id))])
@@ -216,7 +216,7 @@ extension SonarrAPI {
             let body = EpisodeDeleteResource(episodeFileIds: files.map(\.id))
 
             return try await API.request(method: .delete, url: url, body: body, instance: instance)
-        }, episodeCalendar: { start, end, instance in
+        }, calendar: { start, end, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/calendar")
                 .appending(queryItems: [
@@ -245,7 +245,7 @@ extension InstanceAPI {
                 .appending(path: "/api/v3/release")
 
             return try await API.request(method: .post, url: url, body: payload, instance: instance, timeout: .sluggish)
-        }, systemStatus: { instance in
+        }, status: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/system/status")
 
@@ -259,17 +259,17 @@ extension InstanceAPI {
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/qualityprofile")
             return try await API.request(url: url, instance: instance)
-        }, fetchDiskSpace: { instance in
+        }, diskSpace: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/diskspace")
 
             return try await API.request(url: url, instance: instance)
-        }, getTags: { instance in
+        }, tags: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/tag")
 
             return try await API.request(url: url, instance: instance)
-        }, fetchQueueTasks: { instance in
+        }, queue: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/queue")
                 .appending(queryItems: [
@@ -293,7 +293,7 @@ extension InstanceAPI {
                 ])
 
             return try await API.request(method: .delete, url: url, instance: instance)
-        }, fetchImportableFiles: { downloadId, instance in
+        }, importableFiles: { downloadId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/manualimport")
                 .appending(queryItems: [
@@ -302,7 +302,7 @@ extension InstanceAPI {
                 ])
 
             return try await API.request(url: url, instance: instance, timeout: .sluggish)
-        }, fetchHistory: { type, page, limit, instance in
+        }, history: { type, page, limit, instance in
             var url = try await instance.baseURL()
                 .appending(path: "/api/v3/history")
                 .appending(queryItems: [
@@ -317,7 +317,7 @@ extension InstanceAPI {
             var history: MediaHistory = try await API.request(url: url, instance: instance)
             history.records.stamp(instance.id)
             return history
-        }, fetchNotifications: { instance in
+        }, notifications: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/notification")
 

--- a/Ruddarr/Dependencies/API/API+Live.swift
+++ b/Ruddarr/Dependencies/API/API+Live.swift
@@ -2,11 +2,17 @@ import Foundation
 
 extension API {
     static var live: Self {
+        .init(radarr: .live, sonarr: .live, instance: .live)
+    }
+}
+
+extension RadarrAPI {
+    static var live: Self {
         .init(fetchMovies: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
 
-            var movies: [Movie] = try await request(url: url, instance: instance, timeout: .slow)
+            var movies: [Movie] = try await API.request(url: url, instance: instance, timeout: .slow)
             movies.stamp(instance.id)
             return movies
         }, lookupMovies: { instance, query in
@@ -14,19 +20,19 @@ extension API {
                 .appending(path: "/api/v3/movie/lookup")
                 .appending(queryItems: [.init(name: "term", value: query)])
 
-            return try await request(url: url, instance: instance, timeout: .sluggish)
+            return try await API.request(url: url, instance: instance, timeout: .sluggish)
         }, lookupMovieReleases: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/release")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
-            return try await request(url: url, instance: instance, timeout: .releaseSearch)
+            return try await API.request(url: url, instance: instance, timeout: .releaseSearch)
         }, getMovie: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
                 .appending(path: String(movieId))
 
-            var movie: Movie = try await request(url: url, instance: instance)
+            var movie: Movie = try await API.request(url: url, instance: instance)
             movie.stamp(instance.id)
             return movie
         }, getMovieHistory: { movieId, instance in
@@ -34,24 +40,24 @@ extension API {
                 .appending(path: "/api/v3/history/movie")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, getMovieFiles: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/moviefile")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, getMovieExtraFiles: { movieId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/extrafile")
                 .appending(queryItems: [.init(name: "movieId", value: String(movieId))])
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, addMovie: { movie, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
 
-            return try await request(method: .post, url: url, body: movie, instance: instance)
+            return try await API.request(method: .post, url: url, body: movie, instance: instance)
         }, updateMovie: { movie, moveFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie/editor")
@@ -67,7 +73,7 @@ extension API {
                 moveFiles: moveFiles ? true : nil
             )
 
-            return try await request(method: .put, url: url, body: body, instance: instance)
+            return try await API.request(method: .put, url: url, body: body, instance: instance)
         }, deleteMovie: { movie, addExclusion, deleteFildes, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/movie")
@@ -77,18 +83,36 @@ extension API {
                     .init(name: "addImportExclusion", value: addExclusion ? "true" : "false"),
                 ])
 
-            return try await request(method: .delete, url: url, instance: instance)
+            return try await API.request(method: .delete, url: url, instance: instance)
         }, deleteMovieFile: { file, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/moviefile")
                 .appending(path: String(file.id))
 
-            return try await request(method: .delete, url: url, instance: instance)
-        }, fetchSeries: { instance in
+            return try await API.request(method: .delete, url: url, instance: instance)
+        }, movieCalendar: { start, end, instance in
+            let url = try await instance.baseURL()
+                .appending(path: "/api/v3/calendar")
+                .appending(queryItems: [
+                    .init(name: "unmonitored", value: "true"),
+                    .init(name: "start", value: start.formatted(.iso8601)),
+                    .init(name: "end", value: end.formatted(.iso8601)),
+                ])
+
+            var movies: [Movie] = try await API.request(url: url, instance: instance, timeout: .slow)
+            movies.stamp(instance.id)
+            return movies
+        })
+    }
+}
+
+extension SonarrAPI {
+    static var live: Self {
+        .init(fetchSeries: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
 
-            var series: [Series] = try await request(url: url, instance: instance, timeout: .slow)
+            var series: [Series] = try await API.request(url: url, instance: instance, timeout: .slow)
             series.stamp(instance.id)
             return series
         }, fetchEpisodes: { seriesId, instance in
@@ -99,7 +123,7 @@ extension API {
                     .init(name: "includeEpisodeFile", value: "true"),
                 ])
 
-            var episodes: [Episode] = try await request(url: url, instance: instance)
+            var episodes: [Episode] = try await API.request(url: url, instance: instance)
             episodes.stamp(instance.id)
             return episodes
         }, lookupSeries: { instance, query in
@@ -107,7 +131,7 @@ extension API {
                 .appending(path: "/api/v3/series/lookup")
                 .appending(queryItems: [.init(name: "term", value: query)])
 
-            return try await request(url: url, instance: instance, timeout: .sluggish)
+            return try await API.request(url: url, instance: instance, timeout: .sluggish)
         }, lookupSeriesReleases: { seriesId, seasonId, episodeId, instance in
             var url = try await instance.baseURL()
                 .appending(path: "/api/v3/release")
@@ -118,26 +142,26 @@ extension API {
                 url = url.appending(queryItems: [.init(name: "seriesId", value: String(seriesId!)), .init(name: "seasonNumber", value: String(seasonId!))])
             }
 
-            return try await request(url: url, instance: instance, timeout: .releaseSearch)
+            return try await API.request(url: url, instance: instance, timeout: .releaseSearch)
         }, getSeries: { seriesId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
                 .appending(path: String(seriesId))
 
-            var series: Series = try await request(url: url, instance: instance)
+            var series: Series = try await API.request(url: url, instance: instance)
             series.stamp(instance.id)
             return series
         }, addSeries: { series, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
 
-            return try await request(method: .post, url: url, body: series, instance: instance)
+            return try await API.request(method: .post, url: url, body: series, instance: instance)
         }, pushSeries: { series, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
                 .appending(path: String(series.id))
 
-            return try await request(method: .put, url: url, body: series, instance: instance)
+            return try await API.request(method: .put, url: url, body: series, instance: instance)
         }, updateSeries: { series, moveFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series/editor")
@@ -155,7 +179,7 @@ extension API {
                 moveFiles: moveFiles ? true : nil
             )
 
-            return try await request(method: .put, url: url, body: body, instance: instance)
+            return try await API.request(method: .put, url: url, body: body, instance: instance)
         }, deleteSeries: { series, addExclusion, deleteFiles, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/series")
@@ -165,45 +189,33 @@ extension API {
                     .init(name: "addImportListExclusion", value: addExclusion ? "true" : "false"),
                 ])
 
-            return try await request(method: .delete, url: url, instance: instance)
+            return try await API.request(method: .delete, url: url, instance: instance)
         }, monitorEpisode: { ids, monitored, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/episode/monitor")
 
             let body = EpisodesMonitorResource(episodeIds: ids, monitored: monitored)
 
-            return try await request(method: .put, url: url, body: body, instance: instance)
+            return try await API.request(method: .put, url: url, body: body, instance: instance)
         }, getEpisodeHistory: { id, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/history")
                 .appending(queryItems: [.init(name: "episodeId", value: String(id))])
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, deleteEpisodeFile: { file, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/episodefile")
                 .appending(path: String(file.id))
 
-            return try await request(method: .delete, url: url, instance: instance)
+            return try await API.request(method: .delete, url: url, instance: instance)
         }, deleteEpisodeFiles: { files, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/episodefile/bulk")
 
             let body = EpisodeDeleteResource(episodeFileIds: files.map(\.id))
 
-            return try await request(method: .delete, url: url, body: body, instance: instance)
-        }, movieCalendar: { start, end, instance in
-            let url = try await instance.baseURL()
-                .appending(path: "/api/v3/calendar")
-                .appending(queryItems: [
-                    .init(name: "unmonitored", value: "true"),
-                    .init(name: "start", value: start.formatted(.iso8601)),
-                    .init(name: "end", value: end.formatted(.iso8601)),
-                ])
-
-            var movies: [Movie] = try await request(url: url, instance: instance, timeout: .slow)
-            movies.stamp(instance.id)
-            return movies
+            return try await API.request(method: .delete, url: url, body: body, instance: instance)
         }, episodeCalendar: { start, end, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/calendar")
@@ -214,43 +226,49 @@ extension API {
                     .init(name: "end", value: end.formatted(.iso8601)),
                 ])
 
-            var episodes: [Episode] = try await request(url: url, instance: instance, timeout: .slow)
+            var episodes: [Episode] = try await API.request(url: url, instance: instance, timeout: .slow)
             episodes.stamp(instance.id)
             return episodes
-        }, command: { command, instance in
+        })
+    }
+}
+
+extension InstanceAPI {
+    static var live: Self {
+        .init(command: { command, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/command")
 
-            return try await request(method: .post, url: url, body: command.payload, instance: instance)
+            return try await API.request(method: .post, url: url, body: command.payload, instance: instance)
         }, downloadRelease: { payload, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/release")
 
-            return try await request(method: .post, url: url, body: payload, instance: instance, timeout: .sluggish)
+            return try await API.request(method: .post, url: url, body: payload, instance: instance, timeout: .sluggish)
         }, systemStatus: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/system/status")
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, rootFolders: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/rootfolder")
 
-            return try await request(url: url, instance: instance, timeout: .slow)
+            return try await API.request(url: url, instance: instance, timeout: .slow)
         }, qualityProfiles: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/qualityprofile")
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, fetchDiskSpace: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/diskspace")
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, getTags: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/tag")
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, fetchQueueTasks: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/queue")
@@ -261,7 +279,7 @@ extension API {
                     .init(name: "pageSize", value: "250"),
                 ])
 
-            var items: QueueItems = try await request(url: url, instance: instance)
+            var items: QueueItems = try await API.request(url: url, instance: instance)
             items.records.stamp(instance.id)
             return items
         }, deleteQueueTask: { task, remove, block, search, instance in
@@ -274,7 +292,7 @@ extension API {
                     .init(name: "skipRedownload", value: search ? "false" : "true"),
                 ])
 
-            return try await request(method: .delete, url: url, instance: instance)
+            return try await API.request(method: .delete, url: url, instance: instance)
         }, fetchImportableFiles: { downloadId, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/manualimport")
@@ -283,7 +301,7 @@ extension API {
                     .init(name: "filterExistingFiles", value: "false"),
                 ])
 
-            return try await request(url: url, instance: instance, timeout: .sluggish)
+            return try await API.request(url: url, instance: instance, timeout: .sluggish)
         }, fetchHistory: { type, page, limit, instance in
             var url = try await instance.baseURL()
                 .appending(path: "/api/v3/history")
@@ -296,31 +314,31 @@ extension API {
                 url = url.appending(queryItems: [.init(name: "eventType", value: String(type))])
             }
 
-            var history: MediaHistory = try await request(url: url, instance: instance)
+            var history: MediaHistory = try await API.request(url: url, instance: instance)
             history.records.stamp(instance.id)
             return history
         }, fetchNotifications: { instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/notification")
 
-            return try await request(url: url, instance: instance)
+            return try await API.request(url: url, instance: instance)
         }, createNotification: { model, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/notification")
 
-            return try await request(method: .post, url: url, body: model, instance: instance)
+            return try await API.request(method: .post, url: url, body: model, instance: instance)
         }, updateNotification: { model, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/notification")
                 .appending(path: String(model.id ?? 0))
 
-            return try await request(method: .put, url: url, body: model, instance: instance)
+            return try await API.request(method: .put, url: url, body: model, instance: instance)
         }, deleteNotification: { model, instance in
             let url = try await instance.baseURL()
                 .appending(path: "/api/v3/notification")
                 .appending(path: String(model.id ?? 0))
 
-            return try await request(method: .delete, url: url, instance: instance)
+            return try await API.request(method: .delete, url: url, instance: instance)
         })
     }
 }

--- a/Ruddarr/Dependencies/API/API+Mock.swift
+++ b/Ruddarr/Dependencies/API/API+Mock.swift
@@ -2,6 +2,12 @@ import Foundation
 
 extension API {
     static var mock: Self {
+        .init(radarr: .mock, sonarr: .mock, instance: .mock)
+    }
+}
+
+extension RadarrAPI {
+    static var mock: Self {
         .init(fetchMovies: { _ in
             try await Task.sleep(for: .seconds(1))
 
@@ -45,16 +51,27 @@ extension API {
         }, updateMovie: { _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, deleteMovie: { _, _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, deleteMovieFile: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
-        }, fetchSeries: { _ in
+            return API.Empty()
+        }, movieCalendar: { _, _, instance in
+            try await Task.sleep(for: .seconds(2))
+            let movies: [Movie] = loadPreviewData(filename: "calendar-movies")
+
+            return modifyCalendarMovies(movies, instance)
+        })
+    }
+}
+
+extension SonarrAPI {
+    static var mock: Self {
+        .init(fetchSeries: { _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "series")
@@ -88,15 +105,15 @@ extension API {
         }, updateSeries: { _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, deleteSeries: { _, _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, monitorEpisode: { _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, getEpisodeHistory: { _, _ in
             let events: MediaHistory = loadPreviewData(filename: "series-episode-history")
             try await Task.sleep(for: .seconds(2))
@@ -105,29 +122,30 @@ extension API {
         }, deleteEpisodeFile: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, deleteEpisodeFiles: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
-        }, movieCalendar: { _, _, instance in
-            try await Task.sleep(for: .seconds(2))
-            let movies: [Movie] = loadPreviewData(filename: "calendar-movies")
-
-            return modifyCalendarMovies(movies, instance)
+            return API.Empty()
         }, episodeCalendar: { _, _, instance in
             try await Task.sleep(for: .seconds(3))
             let episodes: [Episode] = loadPreviewData(filename: "calendar-episodes")
 
             return modifyCalendarEpisodes(episodes, instance)
-        }, command: { _, _ in
+        })
+    }
+}
+
+extension InstanceAPI {
+    static var mock: Self {
+        .init(command: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         }, downloadRelease: { _, _ in
             try await Task.sleep(for: .seconds(1))
 
-            return Empty()
+            return API.Empty()
         }, systemStatus: { instance in
             try await Task.sleep(for: .seconds(2))
 
@@ -163,7 +181,7 @@ extension API {
         }, deleteQueueTask: { _, _, _, _, _ in
             try await Task.sleep(for: .seconds(3))
 
-            return Empty()
+            return API.Empty()
         }, fetchImportableFiles: { _, instance in
             try await Task.sleep(for: .seconds(1))
 
@@ -197,28 +215,26 @@ extension API {
         }, deleteNotification: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
-            return Empty()
+            return API.Empty()
         })
     }
 }
 
-fileprivate extension API {
-    static func loadPreviewData<Model: Decodable>(filename: String) -> Model {
-        if let path = Bundle.main.path(forResource: filename, ofType: "json") {
-            do {
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601extended
+private func loadPreviewData<Model: Decodable>(filename: String) -> Model {
+    if let path = Bundle.main.path(forResource: filename, ofType: "json") {
+        do {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601extended
 
-                let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
 
-                return try decoder.decode(Model.self, from: data)
-            } catch {
-                fatalError("Preview data `\(filename)` could not be decoded: \(error)")
-            }
+            return try decoder.decode(Model.self, from: data)
+        } catch {
+            fatalError("Preview data `\(filename)` could not be decoded: \(error)")
         }
-
-        fatalError("Preview data `\(filename)` not found")
     }
+
+    fatalError("Preview data `\(filename)` not found")
 }
 
 private func modifyQueueItems(_ items: QueueItems, _ instance: Instance) -> QueueItems {

--- a/Ruddarr/Dependencies/API/API+Mock.swift
+++ b/Ruddarr/Dependencies/API/API+Mock.swift
@@ -8,59 +8,59 @@ extension API {
 
 extension RadarrAPI {
     static var mock: Self {
-        .init(fetchMovies: { _ in
+        .init(fetch: { _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "movies")
-        }, lookupMovies: { _, query in
+        }, lookup: { _, query in
             let movies: [Movie] = loadPreviewData(filename: "movie-lookup")
             try await Task.sleep(for: .seconds(1))
 
             return movies.filter {
                 $0.title.localizedCaseInsensitiveContains(query)
             }
-        }, lookupMovieReleases: { _, _ in
+        }, releases: { _, _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "movie-releases")
-        }, getMovie: { movieId, _ in
+        }, movie: { movieId, _ in
             let movies: [Movie] = loadPreviewData(filename: "movies")
             try await Task.sleep(for: .seconds(2))
 
             return movies.first(where: { $0.guid == movieId })!
-        }, getMovieHistory: { _, _ in
+        }, history: { _, _ in
             let events: [MediaHistoryEvent] = loadPreviewData(filename: "movie-history")
             try await Task.sleep(for: .seconds(1))
 
             return events
-        }, getMovieFiles: { _, _ in
+        }, files: { _, _ in
             let files: [MediaFile] = loadPreviewData(filename: "movie-files")
             try await Task.sleep(for: .seconds(1))
 
             return files
-        }, getMovieExtraFiles: { _, _ in
+        }, extraFiles: { _, _ in
             let files: [MovieExtraFile] = loadPreviewData(filename: "movie-extra-files")
             // try await Task.sleep(for: .seconds(1))
 
             return files
-        }, addMovie: { _, _ in
+        }, add: { _, _ in
             let movies: [Movie] = loadPreviewData(filename: "movies")
             try await Task.sleep(for: .seconds(2))
 
             return movies[0]
-        }, updateMovie: { _, _, _ in
+        }, update: { _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, deleteMovie: { _, _, _, _ in
+        }, delete: { _, _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, deleteMovieFile: { _, _ in
+        }, deleteFile: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, movieCalendar: { _, _, instance in
+        }, calendar: { _, _, instance in
             try await Task.sleep(for: .seconds(2))
             let movies: [Movie] = loadPreviewData(filename: "calendar-movies")
 
@@ -71,42 +71,42 @@ extension RadarrAPI {
 
 extension SonarrAPI {
     static var mock: Self {
-        .init(fetchSeries: { _ in
+        .init(fetch: { _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "series")
-        }, fetchEpisodes: { _, _ in
+        }, episodes: { _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return loadPreviewData(filename: "series-episodes")
-        }, lookupSeries: { _, _ in
+        }, lookup: { _, _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "series-lookup")
-        }, lookupSeriesReleases: { _, _, _, _ in
+        }, releases: { _, _, _, _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "series-releases")
-        }, getSeries: { _, _ in
+        }, series: { _, _ in
             let series: [Series] = loadPreviewData(filename: "series")
             try await Task.sleep(for: .seconds(1))
 
             return series[0]
-        }, addSeries: { _, _ in
+        }, add: { _, _ in
             let series: [Series] = loadPreviewData(filename: "series")
             try await Task.sleep(for: .seconds(2))
 
             return series[0]
-        }, pushSeries: { _, _ in
+        }, push: { _, _ in
             let series: [Series] = loadPreviewData(filename: "series")
             try await Task.sleep(for: .seconds(2))
 
             return series[0]
-        }, updateSeries: { _, _, _ in
+        }, update: { _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, deleteSeries: { _, _, _, _ in
+        }, delete: { _, _, _, _ in
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
@@ -114,7 +114,7 @@ extension SonarrAPI {
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, getEpisodeHistory: { _, _ in
+        }, episodeHistory: { _, _ in
             let events: MediaHistory = loadPreviewData(filename: "series-episode-history")
             try await Task.sleep(for: .seconds(2))
 
@@ -127,7 +127,7 @@ extension SonarrAPI {
             try await Task.sleep(for: .seconds(2))
 
             return API.Empty()
-        }, episodeCalendar: { _, _, instance in
+        }, calendar: { _, _, instance in
             try await Task.sleep(for: .seconds(3))
             let episodes: [Episode] = loadPreviewData(filename: "calendar-episodes")
 
@@ -146,7 +146,7 @@ extension InstanceAPI {
             try await Task.sleep(for: .seconds(1))
 
             return API.Empty()
-        }, systemStatus: { instance in
+        }, status: { instance in
             try await Task.sleep(for: .seconds(2))
 
             return InstanceStatus(
@@ -162,15 +162,15 @@ extension InstanceAPI {
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "quality-profiles")
-        }, fetchDiskSpace: { _ in
+        }, diskSpace: { _ in
             try await Task.sleep(for: .seconds(1))
 
             return loadPreviewData(filename: "disk-space")
-        }, getTags: { _ in
+        }, tags: { _ in
             try await Task.sleep(for: .seconds(1))
             let tags: [Tag] = loadPreviewData(filename: "tags")
             return tags
-        }, fetchQueueTasks: { instance in
+        }, queue: { instance in
             try await Task.sleep(for: .seconds(1))
 
             let items: QueueItems = loadPreviewData(
@@ -182,7 +182,7 @@ extension InstanceAPI {
             try await Task.sleep(for: .seconds(3))
 
             return API.Empty()
-        }, fetchImportableFiles: { _, instance in
+        }, importableFiles: { _, instance in
             try await Task.sleep(for: .seconds(1))
 
             let files: [ImportableFile] = loadPreviewData(
@@ -190,7 +190,7 @@ extension InstanceAPI {
             )
 
             return files
-        }, fetchHistory: { _, _, _, instance in
+        }, history: { _, _, _, instance in
             try await Task.sleep(for: .seconds(2))
 
             let events: MediaHistory = loadPreviewData(
@@ -198,7 +198,7 @@ extension InstanceAPI {
             )
 
             return events
-        }, fetchNotifications: { _ in
+        }, notifications: { _ in
             try await Task.sleep(for: .seconds(2))
 
             return loadPreviewData(filename: "notifications")

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -1,6 +1,13 @@
 import Sentry
 
 struct API: Sendable {
+    var radarr: RadarrAPI
+    var sonarr: SonarrAPI
+    var instance: InstanceAPI
+}
+
+/// Endpoints only Radarr serves, or that only make sense against a Radarr instance.
+struct RadarrAPI: Sendable {
     var fetchMovies: @Sendable (Instance) async throws -> [Movie]
     var lookupMovies: @Sendable (_ instance: Instance, _ query: String) async throws -> [Movie]
     var lookupMovieReleases: @Sendable (Movie.ID, Instance) async throws -> [MovieRelease]
@@ -10,10 +17,15 @@ struct API: Sendable {
     var getMovieFiles: @Sendable (Movie.ID, Instance) async throws -> [MediaFile]
     var getMovieExtraFiles: @Sendable (Movie.ID, Instance) async throws -> [MovieExtraFile]
     var addMovie: @Sendable (Movie, Instance) async throws -> Movie
-    var updateMovie: @Sendable (Movie, Bool, Instance) async throws -> Empty
-    var deleteMovie: @Sendable (Movie, Bool, Bool, Instance) async throws -> Empty
-    var deleteMovieFile: @Sendable (MediaFile, Instance) async throws -> Empty
+    var updateMovie: @Sendable (Movie, Bool, Instance) async throws -> API.Empty
+    var deleteMovie: @Sendable (Movie, Bool, Bool, Instance) async throws -> API.Empty
+    var deleteMovieFile: @Sendable (MediaFile, Instance) async throws -> API.Empty
 
+    var movieCalendar: @Sendable (Date, Date, Instance) async throws -> [Movie]
+}
+
+/// Endpoints only Sonarr serves, or that only make sense against a Sonarr instance.
+struct SonarrAPI: Sendable {
     var fetchSeries: @Sendable (Instance) async throws -> [Series]
     var fetchEpisodes: @Sendable (Series.ID, Instance) async throws -> [Episode]
     var lookupSeries: @Sendable (_ instance: Instance, _ query: String) async throws -> [Series]
@@ -22,19 +34,24 @@ struct API: Sendable {
     var getSeries: @Sendable (Series.ID, Instance) async throws -> Series
     var addSeries: @Sendable (Series, Instance) async throws -> Series
     var pushSeries: @Sendable (Series, Instance) async throws -> Series
-    var updateSeries: @Sendable (Series, Bool, Instance) async throws -> Empty
-    var deleteSeries: @Sendable (Series, Bool, Bool, Instance) async throws -> Empty
+    var updateSeries: @Sendable (Series, Bool, Instance) async throws -> API.Empty
+    var deleteSeries: @Sendable (Series, Bool, Bool, Instance) async throws -> API.Empty
 
-    var monitorEpisode: @Sendable ([Episode.ID], Bool, Instance) async throws -> Empty
+    var monitorEpisode: @Sendable ([Episode.ID], Bool, Instance) async throws -> API.Empty
     var getEpisodeHistory: @Sendable (Episode.ID, Instance) async throws -> MediaHistory
-    var deleteEpisodeFile: @Sendable (MediaFile, Instance) async throws -> Empty
-    var deleteEpisodeFiles: @Sendable ([MediaFile], Instance) async throws -> Empty
+    var deleteEpisodeFile: @Sendable (MediaFile, Instance) async throws -> API.Empty
+    var deleteEpisodeFiles: @Sendable ([MediaFile], Instance) async throws -> API.Empty
 
-    var movieCalendar: @Sendable (Date, Date, Instance) async throws -> [Movie]
     var episodeCalendar: @Sendable (Date, Date, Instance) async throws -> [Episode]
+}
 
-    var command: @Sendable (InstanceCommand, Instance) async throws -> Empty
-    var downloadRelease: @Sendable (DownloadReleaseCommand, Instance) async throws -> Empty
+/// Endpoints both Radarr and Sonarr serve identically, callable with any `Instance`.
+///
+/// `command` and `downloadRelease` share a route across both apps and discriminate
+/// on their payload (see `InstanceCommand.payload` and `DownloadReleaseCommand`).
+struct InstanceAPI: Sendable {
+    var command: @Sendable (InstanceCommand, Instance) async throws -> API.Empty
+    var downloadRelease: @Sendable (DownloadReleaseCommand, Instance) async throws -> API.Empty
 
     var systemStatus: @Sendable (Instance) async throws -> InstanceStatus
     var rootFolders: @Sendable (Instance) async throws -> [InstanceRootFolder]
@@ -43,7 +60,7 @@ struct API: Sendable {
     var getTags: @Sendable (Instance) async throws -> [Tag]
 
     var fetchQueueTasks: @Sendable (Instance) async throws -> QueueItems
-    var deleteQueueTask: @Sendable (QueueItem.ID, Bool, Bool, Bool, Instance) async throws -> Empty
+    var deleteQueueTask: @Sendable (QueueItem.ID, Bool, Bool, Bool, Instance) async throws -> API.Empty
 
     var fetchImportableFiles: @Sendable (String, Instance) async throws -> [ImportableFile]
 
@@ -52,7 +69,7 @@ struct API: Sendable {
     var fetchNotifications: @Sendable (Instance) async throws -> [InstanceNotification]
     var createNotification: @Sendable (InstanceNotification, Instance) async throws -> InstanceNotification
     var updateNotification: @Sendable (InstanceNotification, Instance) async throws -> InstanceNotification
-    var deleteNotification: @Sendable (InstanceNotification, Instance) async throws -> Empty
+    var deleteNotification: @Sendable (InstanceNotification, Instance) async throws -> API.Empty
 }
 
 extension API {

--- a/Ruddarr/Dependencies/API/API.swift
+++ b/Ruddarr/Dependencies/API/API.swift
@@ -8,41 +8,41 @@ struct API: Sendable {
 
 /// Endpoints only Radarr serves, or that only make sense against a Radarr instance.
 struct RadarrAPI: Sendable {
-    var fetchMovies: @Sendable (Instance) async throws -> [Movie]
-    var lookupMovies: @Sendable (_ instance: Instance, _ query: String) async throws -> [Movie]
-    var lookupMovieReleases: @Sendable (Movie.ID, Instance) async throws -> [MovieRelease]
+    var fetch: @Sendable (Instance) async throws -> [Movie]
+    var lookup: @Sendable (_ instance: Instance, _ query: String) async throws -> [Movie]
+    var releases: @Sendable (Movie.ID, Instance) async throws -> [MovieRelease]
 
-    var getMovie: @Sendable (Movie.ID, Instance) async throws -> Movie
-    var getMovieHistory: @Sendable (Movie.ID, Instance) async throws -> [MediaHistoryEvent]
-    var getMovieFiles: @Sendable (Movie.ID, Instance) async throws -> [MediaFile]
-    var getMovieExtraFiles: @Sendable (Movie.ID, Instance) async throws -> [MovieExtraFile]
-    var addMovie: @Sendable (Movie, Instance) async throws -> Movie
-    var updateMovie: @Sendable (Movie, Bool, Instance) async throws -> API.Empty
-    var deleteMovie: @Sendable (Movie, Bool, Bool, Instance) async throws -> API.Empty
-    var deleteMovieFile: @Sendable (MediaFile, Instance) async throws -> API.Empty
+    var movie: @Sendable (Movie.ID, Instance) async throws -> Movie
+    var history: @Sendable (Movie.ID, Instance) async throws -> [MediaHistoryEvent]
+    var files: @Sendable (Movie.ID, Instance) async throws -> [MediaFile]
+    var extraFiles: @Sendable (Movie.ID, Instance) async throws -> [MovieExtraFile]
+    var add: @Sendable (Movie, Instance) async throws -> Movie
+    var update: @Sendable (Movie, Bool, Instance) async throws -> API.Empty
+    var delete: @Sendable (Movie, Bool, Bool, Instance) async throws -> API.Empty
+    var deleteFile: @Sendable (MediaFile, Instance) async throws -> API.Empty
 
-    var movieCalendar: @Sendable (Date, Date, Instance) async throws -> [Movie]
+    var calendar: @Sendable (Date, Date, Instance) async throws -> [Movie]
 }
 
 /// Endpoints only Sonarr serves, or that only make sense against a Sonarr instance.
 struct SonarrAPI: Sendable {
-    var fetchSeries: @Sendable (Instance) async throws -> [Series]
-    var fetchEpisodes: @Sendable (Series.ID, Instance) async throws -> [Episode]
-    var lookupSeries: @Sendable (_ instance: Instance, _ query: String) async throws -> [Series]
-    var lookupSeriesReleases: @Sendable (Series.ID?, Series.ID?, Episode.ID?, Instance) async throws -> [SeriesRelease]
+    var fetch: @Sendable (Instance) async throws -> [Series]
+    var episodes: @Sendable (Series.ID, Instance) async throws -> [Episode]
+    var lookup: @Sendable (_ instance: Instance, _ query: String) async throws -> [Series]
+    var releases: @Sendable (Series.ID?, Series.ID?, Episode.ID?, Instance) async throws -> [SeriesRelease]
 
-    var getSeries: @Sendable (Series.ID, Instance) async throws -> Series
-    var addSeries: @Sendable (Series, Instance) async throws -> Series
-    var pushSeries: @Sendable (Series, Instance) async throws -> Series
-    var updateSeries: @Sendable (Series, Bool, Instance) async throws -> API.Empty
-    var deleteSeries: @Sendable (Series, Bool, Bool, Instance) async throws -> API.Empty
+    var series: @Sendable (Series.ID, Instance) async throws -> Series
+    var add: @Sendable (Series, Instance) async throws -> Series
+    var push: @Sendable (Series, Instance) async throws -> Series
+    var update: @Sendable (Series, Bool, Instance) async throws -> API.Empty
+    var delete: @Sendable (Series, Bool, Bool, Instance) async throws -> API.Empty
 
     var monitorEpisode: @Sendable ([Episode.ID], Bool, Instance) async throws -> API.Empty
-    var getEpisodeHistory: @Sendable (Episode.ID, Instance) async throws -> MediaHistory
+    var episodeHistory: @Sendable (Episode.ID, Instance) async throws -> MediaHistory
     var deleteEpisodeFile: @Sendable (MediaFile, Instance) async throws -> API.Empty
     var deleteEpisodeFiles: @Sendable ([MediaFile], Instance) async throws -> API.Empty
 
-    var episodeCalendar: @Sendable (Date, Date, Instance) async throws -> [Episode]
+    var calendar: @Sendable (Date, Date, Instance) async throws -> [Episode]
 }
 
 /// Endpoints both Radarr and Sonarr serve identically, callable with any `Instance`.
@@ -53,20 +53,20 @@ struct InstanceAPI: Sendable {
     var command: @Sendable (InstanceCommand, Instance) async throws -> API.Empty
     var downloadRelease: @Sendable (DownloadReleaseCommand, Instance) async throws -> API.Empty
 
-    var systemStatus: @Sendable (Instance) async throws -> InstanceStatus
+    var status: @Sendable (Instance) async throws -> InstanceStatus
     var rootFolders: @Sendable (Instance) async throws -> [InstanceRootFolder]
     var qualityProfiles: @Sendable (Instance) async throws -> [InstanceQualityProfile]
-    var fetchDiskSpace: @Sendable (Instance) async throws -> [InstanceDiskSpace]
-    var getTags: @Sendable (Instance) async throws -> [Tag]
+    var diskSpace: @Sendable (Instance) async throws -> [InstanceDiskSpace]
+    var tags: @Sendable (Instance) async throws -> [Tag]
 
-    var fetchQueueTasks: @Sendable (Instance) async throws -> QueueItems
+    var queue: @Sendable (Instance) async throws -> QueueItems
     var deleteQueueTask: @Sendable (QueueItem.ID, Bool, Bool, Bool, Instance) async throws -> API.Empty
 
-    var fetchImportableFiles: @Sendable (String, Instance) async throws -> [ImportableFile]
+    var importableFiles: @Sendable (String, Instance) async throws -> [ImportableFile]
 
-    var fetchHistory: @Sendable (Int?, Int, Int, Instance) async throws -> MediaHistory
+    var history: @Sendable (Int?, Int, Int, Instance) async throws -> MediaHistory
 
-    var fetchNotifications: @Sendable (Instance) async throws -> [InstanceNotification]
+    var notifications: @Sendable (Instance) async throws -> [InstanceNotification]
     var createNotification: @Sendable (InstanceNotification, Instance) async throws -> InstanceNotification
     var updateNotification: @Sendable (InstanceNotification, Instance) async throws -> InstanceNotification
     var deleteNotification: @Sendable (InstanceNotification, Instance) async throws -> API.Empty

--- a/Ruddarr/Models/Calendar.swift
+++ b/Ruddarr/Models/Calendar.swift
@@ -115,7 +115,7 @@ class MediaCalendar {
     }
 
     private func fetchMovies(_ instance: Instance, _ start: Date, _ end: Date) async throws {
-        let movies = try await dependencies.api.radarr.movieCalendar(start, end, instance)
+        let movies = try await dependencies.api.radarr.calendar(start, end, instance)
 
         for movie in movies {
             if let digitalRelease = movie.digitalRelease {
@@ -150,7 +150,7 @@ class MediaCalendar {
     }
 
     private func fetchEpisodes(_ instance: Instance, _ start: Date, _ end: Date) async throws {
-        let episodes = try await dependencies.api.sonarr.episodeCalendar(start, end, instance)
+        let episodes = try await dependencies.api.sonarr.calendar(start, end, instance)
 
         for episode in episodes {
             if let airDate = episode.airDateUtc {

--- a/Ruddarr/Models/Calendar.swift
+++ b/Ruddarr/Models/Calendar.swift
@@ -115,7 +115,7 @@ class MediaCalendar {
     }
 
     private func fetchMovies(_ instance: Instance, _ start: Date, _ end: Date) async throws {
-        let movies = try await dependencies.api.movieCalendar(start, end, instance)
+        let movies = try await dependencies.api.radarr.movieCalendar(start, end, instance)
 
         for movie in movies {
             if let digitalRelease = movie.digitalRelease {
@@ -150,7 +150,7 @@ class MediaCalendar {
     }
 
     private func fetchEpisodes(_ instance: Instance, _ start: Date, _ end: Date) async throws {
-        let episodes = try await dependencies.api.episodeCalendar(start, end, instance)
+        let episodes = try await dependencies.api.sonarr.episodeCalendar(start, end, instance)
 
         for episode in episodes {
             if let airDate = episode.airDateUtc {

--- a/Ruddarr/Models/History.swift
+++ b/Ruddarr/Models/History.swift
@@ -39,7 +39,7 @@ class History {
 
                     group.addTask {(
                         instance,
-                        try await dependencies.api.instance.fetchHistory(eventType, page, 25, instance)
+                        try await dependencies.api.instance.history(eventType, page, 25, instance)
                     )}
                 }
 

--- a/Ruddarr/Models/History.swift
+++ b/Ruddarr/Models/History.swift
@@ -39,7 +39,7 @@ class History {
 
                     group.addTask {(
                         instance,
-                        try await dependencies.api.fetchHistory(eventType, page, 25, instance)
+                        try await dependencies.api.instance.fetchHistory(eventType, page, 25, instance)
                     )}
                 }
 

--- a/Ruddarr/Models/Instances/InstanceWebhook.swift
+++ b/Ruddarr/Models/Instances/InstanceWebhook.swift
@@ -63,7 +63,7 @@ class InstanceWebhook {
             try await fetchWebhooks()
 
             if let webhook {
-                _ = try await dependencies.api.deleteNotification(webhook, instance)
+                _ = try await dependencies.api.instance.deleteNotification(webhook, instance)
             }
         } catch is CancellationError {
             // do nothing
@@ -76,7 +76,7 @@ class InstanceWebhook {
     }
 
     private func fetchWebhooks() async throws {
-        notifications = try await dependencies.api.fetchNotifications(instance)
+        notifications = try await dependencies.api.instance.fetchNotifications(instance)
 
         if let webhook {
             model = webhook
@@ -90,7 +90,7 @@ class InstanceWebhook {
         )
 
         do {
-            model = try await dependencies.api.createNotification(record, instance)
+            model = try await dependencies.api.instance.createNotification(record, instance)
         } catch is CancellationError {
             // do nothing
         } catch {
@@ -106,7 +106,7 @@ class InstanceWebhook {
         model.fields = webhookFields()
 
         do {
-            model = try await dependencies.api.updateNotification(model, instance)
+            model = try await dependencies.api.instance.updateNotification(model, instance)
         } catch is CancellationError {
             // do nothing
         } catch {

--- a/Ruddarr/Models/Instances/InstanceWebhook.swift
+++ b/Ruddarr/Models/Instances/InstanceWebhook.swift
@@ -76,7 +76,7 @@ class InstanceWebhook {
     }
 
     private func fetchWebhooks() async throws {
-        notifications = try await dependencies.api.instance.fetchNotifications(instance)
+        notifications = try await dependencies.api.instance.notifications(instance)
 
         if let webhook {
             model = webhook

--- a/Ruddarr/Models/Instances/RadarrInstance.swift
+++ b/Ruddarr/Models/Instances/RadarrInstance.swift
@@ -64,7 +64,7 @@ class RadarrInstance {
 
         async let rootFolders = dependencies.api.instance.rootFolders(instance)
         async let qualityProfiles = dependencies.api.instance.qualityProfiles(instance)
-        async let tags = dependencies.api.instance.getTags(instance)
+        async let tags = dependencies.api.instance.tags(instance)
 
         var updated = false
 

--- a/Ruddarr/Models/Instances/RadarrInstance.swift
+++ b/Ruddarr/Models/Instances/RadarrInstance.swift
@@ -62,9 +62,9 @@ class RadarrInstance {
             return nil
         }
 
-        async let rootFolders = dependencies.api.rootFolders(instance)
-        async let qualityProfiles = dependencies.api.qualityProfiles(instance)
-        async let tags = dependencies.api.getTags(instance)
+        async let rootFolders = dependencies.api.instance.rootFolders(instance)
+        async let qualityProfiles = dependencies.api.instance.qualityProfiles(instance)
+        async let tags = dependencies.api.instance.getTags(instance)
 
         var updated = false
 

--- a/Ruddarr/Models/Instances/SonarrInstance.swift
+++ b/Ruddarr/Models/Instances/SonarrInstance.swift
@@ -67,7 +67,7 @@ class SonarrInstance {
 
         async let rootFolders = dependencies.api.instance.rootFolders(instance)
         async let qualityProfiles = dependencies.api.instance.qualityProfiles(instance)
-        async let tags = dependencies.api.instance.getTags(instance)
+        async let tags = dependencies.api.instance.tags(instance)
 
         var updated = false
 

--- a/Ruddarr/Models/Instances/SonarrInstance.swift
+++ b/Ruddarr/Models/Instances/SonarrInstance.swift
@@ -65,9 +65,9 @@ class SonarrInstance {
             return nil
         }
 
-        async let rootFolders = dependencies.api.rootFolders(instance)
-        async let qualityProfiles = dependencies.api.qualityProfiles(instance)
-        async let tags = dependencies.api.getTags(instance)
+        async let rootFolders = dependencies.api.instance.rootFolders(instance)
+        async let qualityProfiles = dependencies.api.instance.qualityProfiles(instance)
+        async let tags = dependencies.api.instance.getTags(instance)
 
         var updated = false
 

--- a/Ruddarr/Models/Movies/MovieLookup.swift
+++ b/Ruddarr/Models/Movies/MovieLookup.swift
@@ -73,7 +73,7 @@ class MovieLookup {
         searchTask = Task {
             do {
                 searchTaskQuery = query
-                items = try await dependencies.api.radarr.lookupMovies(instance, query)
+                items = try await dependencies.api.radarr.lookup(instance, query)
                 searchedQuery = query
             } catch is CancellationError {
                 // do nothing
@@ -99,7 +99,7 @@ class MovieLookup {
             return cached
         }
 
-        let results = try await dependencies.api.radarr.lookupMovies(instance, query)
+        let results = try await dependencies.api.radarr.lookup(instance, query)
 
         if let result = results.first {
             queries[query] = result

--- a/Ruddarr/Models/Movies/MovieLookup.swift
+++ b/Ruddarr/Models/Movies/MovieLookup.swift
@@ -73,7 +73,7 @@ class MovieLookup {
         searchTask = Task {
             do {
                 searchTaskQuery = query
-                items = try await dependencies.api.lookupMovies(instance, query)
+                items = try await dependencies.api.radarr.lookupMovies(instance, query)
                 searchedQuery = query
             } catch is CancellationError {
                 // do nothing
@@ -99,7 +99,7 @@ class MovieLookup {
             return cached
         }
 
-        let results = try await dependencies.api.lookupMovies(instance, query)
+        let results = try await dependencies.api.radarr.lookupMovies(instance, query)
 
         if let result = results.first {
             queries[query] = result

--- a/Ruddarr/Models/Movies/MovieMetadata.swift
+++ b/Ruddarr/Models/Movies/MovieMetadata.swift
@@ -43,8 +43,8 @@ class MovieMetadata {
         filesError = false
 
         do {
-            async let filesResult = dependencies.api.getMovieFiles(movie.id, instance)
-            async let extraFilesResult = dependencies.api.getMovieExtraFiles(movie.id, instance)
+            async let filesResult = dependencies.api.radarr.getMovieFiles(movie.id, instance)
+            async let extraFilesResult = dependencies.api.radarr.getMovieExtraFiles(movie.id, instance)
 
             files = try await filesResult
             extraFiles = try await extraFilesResult
@@ -66,7 +66,7 @@ class MovieMetadata {
         historyError = false
 
         do {
-            history = try await dependencies.api.getMovieHistory(movie.id, instance)
+            history = try await dependencies.api.radarr.getMovieHistory(movie.id, instance)
         } catch is CancellationError {
             // do nothing
         } catch {
@@ -81,8 +81,8 @@ class MovieMetadata {
         historyError = false
 
         do {
-            async let filesResult = dependencies.api.getMovieFiles(movie.id, instance)
-            async let extraFilesResult = dependencies.api.getMovieExtraFiles(movie.id, instance)
+            async let filesResult = dependencies.api.radarr.getMovieFiles(movie.id, instance)
+            async let extraFilesResult = dependencies.api.radarr.getMovieExtraFiles(movie.id, instance)
 
             files = try await filesResult
             extraFiles = try await extraFilesResult
@@ -95,7 +95,7 @@ class MovieMetadata {
         filesLoading = false
 
         do {
-            history = try await dependencies.api.getMovieHistory(movie.id, instance)
+            history = try await dependencies.api.radarr.getMovieHistory(movie.id, instance)
         } catch is CancellationError {
             // do nothing
         } catch {
@@ -107,7 +107,7 @@ class MovieMetadata {
 
     func delete(_ file: MediaFile) async -> Bool {
         do {
-            _ = try await dependencies.api.deleteMovieFile(file, instance)
+            _ = try await dependencies.api.radarr.deleteMovieFile(file, instance)
 
             if let index = files.firstIndex(where: { $0.id == file.id }) {
                 files.remove(at: index)

--- a/Ruddarr/Models/Movies/MovieMetadata.swift
+++ b/Ruddarr/Models/Movies/MovieMetadata.swift
@@ -43,8 +43,8 @@ class MovieMetadata {
         filesError = false
 
         do {
-            async let filesResult = dependencies.api.radarr.getMovieFiles(movie.id, instance)
-            async let extraFilesResult = dependencies.api.radarr.getMovieExtraFiles(movie.id, instance)
+            async let filesResult = dependencies.api.radarr.files(movie.id, instance)
+            async let extraFilesResult = dependencies.api.radarr.extraFiles(movie.id, instance)
 
             files = try await filesResult
             extraFiles = try await extraFilesResult
@@ -66,7 +66,7 @@ class MovieMetadata {
         historyError = false
 
         do {
-            history = try await dependencies.api.radarr.getMovieHistory(movie.id, instance)
+            history = try await dependencies.api.radarr.history(movie.id, instance)
         } catch is CancellationError {
             // do nothing
         } catch {
@@ -81,8 +81,8 @@ class MovieMetadata {
         historyError = false
 
         do {
-            async let filesResult = dependencies.api.radarr.getMovieFiles(movie.id, instance)
-            async let extraFilesResult = dependencies.api.radarr.getMovieExtraFiles(movie.id, instance)
+            async let filesResult = dependencies.api.radarr.files(movie.id, instance)
+            async let extraFilesResult = dependencies.api.radarr.extraFiles(movie.id, instance)
 
             files = try await filesResult
             extraFiles = try await extraFilesResult
@@ -95,7 +95,7 @@ class MovieMetadata {
         filesLoading = false
 
         do {
-            history = try await dependencies.api.radarr.getMovieHistory(movie.id, instance)
+            history = try await dependencies.api.radarr.history(movie.id, instance)
         } catch is CancellationError {
             // do nothing
         } catch {
@@ -107,7 +107,7 @@ class MovieMetadata {
 
     func delete(_ file: MediaFile) async -> Bool {
         do {
-            _ = try await dependencies.api.radarr.deleteMovieFile(file, instance)
+            _ = try await dependencies.api.radarr.deleteFile(file, instance)
 
             if let index = files.firstIndex(where: { $0.id == file.id }) {
                 files.remove(at: index)

--- a/Ruddarr/Models/Movies/MovieReleases.swift
+++ b/Ruddarr/Models/Movies/MovieReleases.swift
@@ -31,7 +31,7 @@ class MovieReleases {
         setFilterData()
 
         do {
-            items = try await dependencies.api.radarr.lookupMovieReleases(movie.id, instance)
+            items = try await dependencies.api.radarr.releases(movie.id, instance)
             setFilterData()
         } catch is CancellationError {
             // do nothing

--- a/Ruddarr/Models/Movies/MovieReleases.swift
+++ b/Ruddarr/Models/Movies/MovieReleases.swift
@@ -31,7 +31,7 @@ class MovieReleases {
         setFilterData()
 
         do {
-            items = try await dependencies.api.lookupMovieReleases(movie.id, instance)
+            items = try await dependencies.api.radarr.lookupMovieReleases(movie.id, instance)
             setFilterData()
         } catch is CancellationError {
             // do nothing

--- a/Ruddarr/Models/Movies/Movies.swift
+++ b/Ruddarr/Models/Movies/Movies.swift
@@ -132,7 +132,7 @@ class Movies {
     private func performOperation(_ operation: Operation) async throws {
         switch operation {
         case .fetch:
-            items = try await dependencies.api.radarr.fetchMovies(instance)
+            items = try await dependencies.api.radarr.fetch(instance)
             itemsCount = items.count
             computeAlternateTitles()
             await Spotlight(instance.id).index(items, delay: .seconds(5))
@@ -141,7 +141,7 @@ class Movies {
 
         case .get(let movie):
             if let index = items.firstIndex(where: { $0.id == movie.id }) {
-                let item = try await dependencies.api.radarr.getMovie(movie.id, instance)
+                let item = try await dependencies.api.radarr.movie(movie.id, instance)
 
                 if items[index] != item {
                     items[index] = item
@@ -149,13 +149,13 @@ class Movies {
             }
 
         case .add(let movie):
-            items.append(try await dependencies.api.radarr.addMovie(movie, instance))
+            items.append(try await dependencies.api.radarr.add(movie, instance))
 
         case .update(let movie, let moveFiles):
-            _ = try await dependencies.api.radarr.updateMovie(movie, moveFiles, instance)
+            _ = try await dependencies.api.radarr.update(movie, moveFiles, instance)
 
         case .delete(let movie, let addExclusion, let deleteFiles):
-            _ = try await dependencies.api.radarr.deleteMovie(movie, addExclusion, deleteFiles, instance)
+            _ = try await dependencies.api.radarr.delete(movie, addExclusion, deleteFiles, instance)
             items.removeAll(where: { $0.guid == movie.guid })
 
         case .download(let guid, let indexerId, let movieId):

--- a/Ruddarr/Models/Movies/Movies.swift
+++ b/Ruddarr/Models/Movies/Movies.swift
@@ -132,7 +132,7 @@ class Movies {
     private func performOperation(_ operation: Operation) async throws {
         switch operation {
         case .fetch:
-            items = try await dependencies.api.fetchMovies(instance)
+            items = try await dependencies.api.radarr.fetchMovies(instance)
             itemsCount = items.count
             computeAlternateTitles()
             await Spotlight(instance.id).index(items, delay: .seconds(5))
@@ -141,7 +141,7 @@ class Movies {
 
         case .get(let movie):
             if let index = items.firstIndex(where: { $0.id == movie.id }) {
-                let item = try await dependencies.api.getMovie(movie.id, instance)
+                let item = try await dependencies.api.radarr.getMovie(movie.id, instance)
 
                 if items[index] != item {
                     items[index] = item
@@ -149,21 +149,21 @@ class Movies {
             }
 
         case .add(let movie):
-            items.append(try await dependencies.api.addMovie(movie, instance))
+            items.append(try await dependencies.api.radarr.addMovie(movie, instance))
 
         case .update(let movie, let moveFiles):
-            _ = try await dependencies.api.updateMovie(movie, moveFiles, instance)
+            _ = try await dependencies.api.radarr.updateMovie(movie, moveFiles, instance)
 
         case .delete(let movie, let addExclusion, let deleteFiles):
-            _ = try await dependencies.api.deleteMovie(movie, addExclusion, deleteFiles, instance)
+            _ = try await dependencies.api.radarr.deleteMovie(movie, addExclusion, deleteFiles, instance)
             items.removeAll(where: { $0.guid == movie.guid })
 
         case .download(let guid, let indexerId, let movieId):
             let payload = DownloadReleaseCommand(guid: guid, indexerId: indexerId, movieId: movieId)
-            _ = try await dependencies.api.downloadRelease(payload, instance)
+            _ = try await dependencies.api.instance.downloadRelease(payload, instance)
 
         case .command(let command):
-            _ = try await dependencies.api.command(command, instance)
+            _ = try await dependencies.api.instance.command(command, instance)
         }
     }
 

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -57,7 +57,7 @@ class Queue {
         await withThrowingTaskGroup(of: (Instance.ID, [QueueItem]).self) { group in
             for instance in instances {
                 group.addTask {
-                    (instance.id, try await dependencies.api.instance.fetchQueueTasks(instance).records)
+                    (instance.id, try await dependencies.api.instance.queue(instance).records)
                 }
             }
 

--- a/Ruddarr/Models/Queue/Queue.swift
+++ b/Ruddarr/Models/Queue/Queue.swift
@@ -57,7 +57,7 @@ class Queue {
         await withThrowingTaskGroup(of: (Instance.ID, [QueueItem]).self) { group in
             for instance in instances {
                 group.addTask {
-                    (instance.id, try await dependencies.api.fetchQueueTasks(instance).records)
+                    (instance.id, try await dependencies.api.instance.fetchQueueTasks(instance).records)
                 }
             }
 
@@ -147,7 +147,7 @@ class Queue {
     func refreshDownloadClients() async {
         for instance in instances {
             do {
-                _ = try await dependencies.api.command(.refreshDownloads, instance)
+                _ = try await dependencies.api.instance.command(.refreshDownloads, instance)
             } catch is CancellationError {
                 // do nothing
             } catch {

--- a/Ruddarr/Models/Series/SeriesEpisodes.swift
+++ b/Ruddarr/Models/Series/SeriesEpisodes.swift
@@ -78,7 +78,7 @@ class SeriesEpisodes {
         }
 
         do {
-            let newItems = try await dependencies.api.sonarr.fetchEpisodes(series.id, instance)
+            let newItems = try await dependencies.api.sonarr.episodes(series.id, instance)
 
             if items != newItems {
                 items = newItems
@@ -125,7 +125,7 @@ class SeriesEpisodes {
 
     func fetchHistory(_ episode: Episode) async {
         do {
-            history = try await dependencies.api.sonarr.getEpisodeHistory(episode.id, instance).records
+            history = try await dependencies.api.sonarr.episodeHistory(episode.id, instance).records
         } catch is CancellationError {
             // do nothing
         } catch let apiError as API.Error {

--- a/Ruddarr/Models/Series/SeriesEpisodes.swift
+++ b/Ruddarr/Models/Series/SeriesEpisodes.swift
@@ -78,7 +78,7 @@ class SeriesEpisodes {
         }
 
         do {
-            let newItems = try await dependencies.api.fetchEpisodes(series.id, instance)
+            let newItems = try await dependencies.api.sonarr.fetchEpisodes(series.id, instance)
 
             if items != newItems {
                 items = newItems
@@ -107,7 +107,7 @@ class SeriesEpisodes {
         isMonitoring = episodes[0]
 
         do {
-            _ = try await dependencies.api.monitorEpisode(episodes, monitored, instance)
+            _ = try await dependencies.api.sonarr.monitorEpisode(episodes, monitored, instance)
         } catch is CancellationError {
             // do nothing
         } catch let apiError as API.Error {
@@ -125,7 +125,7 @@ class SeriesEpisodes {
 
     func fetchHistory(_ episode: Episode) async {
         do {
-            history = try await dependencies.api.getEpisodeHistory(episode.id, instance).records
+            history = try await dependencies.api.sonarr.getEpisodeHistory(episode.id, instance).records
         } catch is CancellationError {
             // do nothing
         } catch let apiError as API.Error {

--- a/Ruddarr/Models/Series/SeriesFiles.swift
+++ b/Ruddarr/Models/Series/SeriesFiles.swift
@@ -17,7 +17,7 @@ class SeriesFiles {
         error = nil
 
         do {
-            _ = try await dependencies.api.deleteEpisodeFile(file, instance)
+            _ = try await dependencies.api.sonarr.deleteEpisodeFile(file, instance)
         } catch is CancellationError {
             // do nothing
         } catch let apiError as API.Error {
@@ -35,7 +35,7 @@ class SeriesFiles {
         error = nil
 
         do {
-            _ = try await dependencies.api.deleteEpisodeFiles(files, instance)
+            _ = try await dependencies.api.sonarr.deleteEpisodeFiles(files, instance)
         } catch is CancellationError {
             // do nothing
         } catch let apiError as API.Error {

--- a/Ruddarr/Models/Series/SeriesLookup.swift
+++ b/Ruddarr/Models/Series/SeriesLookup.swift
@@ -73,7 +73,7 @@ class SeriesLookup {
         searchTask = Task {
             do {
                 searchTaskQuery = query
-                items = try await dependencies.api.sonarr.lookupSeries(instance, query)
+                items = try await dependencies.api.sonarr.lookup(instance, query)
                 searchedQuery = query
             } catch is CancellationError {
                 // do nothing
@@ -99,7 +99,7 @@ class SeriesLookup {
             return cached
         }
 
-        let results = try await dependencies.api.sonarr.lookupSeries(instance, query)
+        let results = try await dependencies.api.sonarr.lookup(instance, query)
 
         if let result = results.first {
             queries[query] = result

--- a/Ruddarr/Models/Series/SeriesLookup.swift
+++ b/Ruddarr/Models/Series/SeriesLookup.swift
@@ -73,7 +73,7 @@ class SeriesLookup {
         searchTask = Task {
             do {
                 searchTaskQuery = query
-                items = try await dependencies.api.lookupSeries(instance, query)
+                items = try await dependencies.api.sonarr.lookupSeries(instance, query)
                 searchedQuery = query
             } catch is CancellationError {
                 // do nothing
@@ -99,7 +99,7 @@ class SeriesLookup {
             return cached
         }
 
-        let results = try await dependencies.api.lookupSeries(instance, query)
+        let results = try await dependencies.api.sonarr.lookupSeries(instance, query)
 
         if let result = results.first {
             queries[query] = result

--- a/Ruddarr/Models/Series/SeriesModel.swift
+++ b/Ruddarr/Models/Series/SeriesModel.swift
@@ -145,7 +145,7 @@ class SeriesModel {
     private func performOperation(_ operation: Operation) async throws {
         switch operation {
         case .fetch:
-            items = try await dependencies.api.sonarr.fetchSeries(instance)
+            items = try await dependencies.api.sonarr.fetch(instance)
             itemsCount = items.count
             computeAlternateTitles()
             await Spotlight(instance.id).index(items, delay: .seconds(5))
@@ -154,7 +154,7 @@ class SeriesModel {
 
         case .get(let series):
             if let index = items.firstIndex(where: { $0.id == series.id }) {
-                let item = try await dependencies.api.sonarr.getSeries(series.id, instance)
+                let item = try await dependencies.api.sonarr.series(series.id, instance)
 
                 if items[index] != item {
                     items[index] = item
@@ -162,16 +162,16 @@ class SeriesModel {
             }
 
         case .add(let series):
-            items.append(try await dependencies.api.sonarr.addSeries(series, instance))
+            items.append(try await dependencies.api.sonarr.add(series, instance))
 
         case .push(let series):
-            _ = try await dependencies.api.sonarr.pushSeries(series, instance)
+            _ = try await dependencies.api.sonarr.push(series, instance)
 
         case .update(let series, let moveFiles):
-            _ = try await dependencies.api.sonarr.updateSeries(series, moveFiles, instance)
+            _ = try await dependencies.api.sonarr.update(series, moveFiles, instance)
 
         case .delete(let series, let addExclusion, let deleteFiles):
-            _ = try await dependencies.api.sonarr.deleteSeries(series, addExclusion, deleteFiles, instance)
+            _ = try await dependencies.api.sonarr.delete(series, addExclusion, deleteFiles, instance)
             items.removeAll(where: { $0.guid == series.guid })
 
         case .download(let guid, let indexerId, let seriesId, let seasonId, let episodeId):

--- a/Ruddarr/Models/Series/SeriesModel.swift
+++ b/Ruddarr/Models/Series/SeriesModel.swift
@@ -145,7 +145,7 @@ class SeriesModel {
     private func performOperation(_ operation: Operation) async throws {
         switch operation {
         case .fetch:
-            items = try await dependencies.api.fetchSeries(instance)
+            items = try await dependencies.api.sonarr.fetchSeries(instance)
             itemsCount = items.count
             computeAlternateTitles()
             await Spotlight(instance.id).index(items, delay: .seconds(5))
@@ -154,7 +154,7 @@ class SeriesModel {
 
         case .get(let series):
             if let index = items.firstIndex(where: { $0.id == series.id }) {
-                let item = try await dependencies.api.getSeries(series.id, instance)
+                let item = try await dependencies.api.sonarr.getSeries(series.id, instance)
 
                 if items[index] != item {
                     items[index] = item
@@ -162,26 +162,26 @@ class SeriesModel {
             }
 
         case .add(let series):
-            items.append(try await dependencies.api.addSeries(series, instance))
+            items.append(try await dependencies.api.sonarr.addSeries(series, instance))
 
         case .push(let series):
-            _ = try await dependencies.api.pushSeries(series, instance)
+            _ = try await dependencies.api.sonarr.pushSeries(series, instance)
 
         case .update(let series, let moveFiles):
-            _ = try await dependencies.api.updateSeries(series, moveFiles, instance)
+            _ = try await dependencies.api.sonarr.updateSeries(series, moveFiles, instance)
 
         case .delete(let series, let addExclusion, let deleteFiles):
-            _ = try await dependencies.api.deleteSeries(series, addExclusion, deleteFiles, instance)
+            _ = try await dependencies.api.sonarr.deleteSeries(series, addExclusion, deleteFiles, instance)
             items.removeAll(where: { $0.guid == series.guid })
 
         case .download(let guid, let indexerId, let seriesId, let seasonId, let episodeId):
             let payload = episodeId == nil
                 ? DownloadReleaseCommand(guid: guid, indexerId: indexerId, seriesId: seriesId, seasonId: seasonId)
                 : DownloadReleaseCommand(guid: guid, indexerId: indexerId, episodeId: episodeId)
-            _ = try await dependencies.api.downloadRelease(payload, instance)
+            _ = try await dependencies.api.instance.downloadRelease(payload, instance)
 
         case .command(let command):
-            _ = try await dependencies.api.command(command, instance)
+            _ = try await dependencies.api.instance.command(command, instance)
         }
     }
 

--- a/Ruddarr/Models/Series/SeriesReleases.swift
+++ b/Ruddarr/Models/Series/SeriesReleases.swift
@@ -31,7 +31,7 @@ class SeriesReleases {
         setFilterData()
 
         do {
-            items = try await dependencies.api.lookupSeriesReleases(series.id, season, episode, instance)
+            items = try await dependencies.api.sonarr.lookupSeriesReleases(series.id, season, episode, instance)
             setFilterData()
         } catch is CancellationError {
             // do nothing

--- a/Ruddarr/Models/Series/SeriesReleases.swift
+++ b/Ruddarr/Models/Series/SeriesReleases.swift
@@ -31,7 +31,7 @@ class SeriesReleases {
         setFilterData()
 
         do {
-            items = try await dependencies.api.sonarr.lookupSeriesReleases(series.id, season, episode, instance)
+            items = try await dependencies.api.sonarr.releases(series.id, season, episode, instance)
             setFilterData()
         } catch is CancellationError {
             // do nothing

--- a/Ruddarr/Views/Activity/TaskImportView.swift
+++ b/Ruddarr/Views/Activity/TaskImportView.swift
@@ -93,7 +93,7 @@ struct TaskImportView: View {
         }
 
         do {
-            files = try await dependencies.api.fetchImportableFiles(downloadId, instance)
+            files = try await dependencies.api.instance.fetchImportableFiles(downloadId, instance)
             selected = Set(files.acceptable().map(\.id))
         } catch is CancellationError {
             // do nothing
@@ -123,7 +123,7 @@ struct TaskImportView: View {
         }
 
         do {
-            _ = try await dependencies.api.command(.manualImport(selectedFiles), instance)
+            _ = try await dependencies.api.instance.command(.manualImport(selectedFiles), instance)
 
             Queue.shared.markImporting(item)
 

--- a/Ruddarr/Views/Activity/TaskImportView.swift
+++ b/Ruddarr/Views/Activity/TaskImportView.swift
@@ -93,7 +93,7 @@ struct TaskImportView: View {
         }
 
         do {
-            files = try await dependencies.api.instance.fetchImportableFiles(downloadId, instance)
+            files = try await dependencies.api.instance.importableFiles(downloadId, instance)
             selected = Set(files.acceptable().map(\.id))
         } catch is CancellationError {
             // do nothing

--- a/Ruddarr/Views/Activity/TaskRemovalView.swift
+++ b/Ruddarr/Views/Activity/TaskRemovalView.swift
@@ -86,7 +86,7 @@ struct TaskRemovalView: View {
         }
 
         do {
-            _ = try await dependencies.api.deleteQueueTask(
+            _ = try await dependencies.api.instance.deleteQueueTask(
                 item.id, remove, block, search, instance
             )
         } catch is CancellationError {

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -349,7 +349,7 @@ private struct CalendarContentSignature: Equatable {
 }
 
 #Preview("Offline") {
-    dependencies.api.movieCalendar = { _, _, _ in
+    dependencies.api.radarr.movieCalendar = { _, _, _ in
         throw API.Error.notConnectedToInternet
     }
 
@@ -360,7 +360,7 @@ private struct CalendarContentSignature: Equatable {
 }
 
 #Preview("Partial Failure") {
-    dependencies.api.episodeCalendar = { _, _, _ in
+    dependencies.api.sonarr.episodeCalendar = { _, _, _ in
         throw API.Error.urlError(
             URLError(.badServerResponse)
         )

--- a/Ruddarr/Views/CalendarView.swift
+++ b/Ruddarr/Views/CalendarView.swift
@@ -349,7 +349,7 @@ private struct CalendarContentSignature: Equatable {
 }
 
 #Preview("Offline") {
-    dependencies.api.radarr.movieCalendar = { _, _, _ in
+    dependencies.api.radarr.calendar = { _, _, _ in
         throw API.Error.notConnectedToInternet
     }
 
@@ -360,7 +360,7 @@ private struct CalendarContentSignature: Equatable {
 }
 
 #Preview("Partial Failure") {
-    dependencies.api.sonarr.episodeCalendar = { _, _, _ in
+    dependencies.api.sonarr.calendar = { _, _, _ in
         throw API.Error.urlError(
             URLError(.badServerResponse)
         )

--- a/Ruddarr/Views/MoviesView.swift
+++ b/Ruddarr/Views/MoviesView.swift
@@ -319,7 +319,7 @@ struct MoviesView: View {
 }
 
 #Preview("Offline") {
-    dependencies.api.radarr.fetchMovies = { _ in
+    dependencies.api.radarr.fetch = { _ in
         throw API.Error.notConnectedToInternet
     }
 
@@ -328,7 +328,7 @@ struct MoviesView: View {
 }
 
 #Preview("Failure") {
-    dependencies.api.radarr.fetchMovies = { _ in
+    dependencies.api.radarr.fetch = { _ in
         throw API.Error.urlError(
             URLError(.badServerResponse)
         )
@@ -339,7 +339,7 @@ struct MoviesView: View {
 }
 
 #Preview("Timeout") {
-    dependencies.api.radarr.fetchMovies = { _ in
+    dependencies.api.radarr.fetch = { _ in
         throw API.Error.timeoutOnPrivateIp(
             URLError(.timedOut)
         )

--- a/Ruddarr/Views/MoviesView.swift
+++ b/Ruddarr/Views/MoviesView.swift
@@ -319,7 +319,7 @@ struct MoviesView: View {
 }
 
 #Preview("Offline") {
-    dependencies.api.fetchMovies = { _ in
+    dependencies.api.radarr.fetchMovies = { _ in
         throw API.Error.notConnectedToInternet
     }
 
@@ -328,7 +328,7 @@ struct MoviesView: View {
 }
 
 #Preview("Failure") {
-    dependencies.api.fetchMovies = { _ in
+    dependencies.api.radarr.fetchMovies = { _ in
         throw API.Error.urlError(
             URLError(.badServerResponse)
         )
@@ -339,7 +339,7 @@ struct MoviesView: View {
 }
 
 #Preview("Timeout") {
-    dependencies.api.fetchMovies = { _ in
+    dependencies.api.radarr.fetchMovies = { _ in
         throw API.Error.timeoutOnPrivateIp(
             URLError(.timedOut)
         )

--- a/Ruddarr/Views/SeriesView.swift
+++ b/Ruddarr/Views/SeriesView.swift
@@ -364,7 +364,7 @@ struct SeriesView: View {
 }
 
 #Preview("Offline") {
-    dependencies.api.fetchSeries = { _ in
+    dependencies.api.sonarr.fetchSeries = { _ in
         throw API.Error.notConnectedToInternet
     }
 

--- a/Ruddarr/Views/SeriesView.swift
+++ b/Ruddarr/Views/SeriesView.swift
@@ -364,7 +364,7 @@ struct SeriesView: View {
 }
 
 #Preview("Offline") {
-    dependencies.api.sonarr.fetchSeries = { _ in
+    dependencies.api.sonarr.fetch = { _ in
         throw API.Error.notConnectedToInternet
     }
 

--- a/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
@@ -143,7 +143,7 @@ extension InstanceEditView {
         let status: InstanceStatus
 
         do {
-            status = try await dependencies.api.instance.systemStatus(instance)
+            status = try await dependencies.api.instance.status(instance)
         } catch let apiError as API.Error {
             throw InstanceError.apiError(apiError)
         } catch {

--- a/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
+++ b/Ruddarr/Views/Settings/InstanceEditView+Functions.swift
@@ -143,7 +143,7 @@ extension InstanceEditView {
         let status: InstanceStatus
 
         do {
-            status = try await dependencies.api.systemStatus(instance)
+            status = try await dependencies.api.instance.systemStatus(instance)
         } catch let apiError as API.Error {
             throw InstanceError.apiError(apiError)
         } catch {

--- a/Ruddarr/Views/Settings/InstanceRow.swift
+++ b/Ruddarr/Views/Settings/InstanceRow.swift
@@ -103,10 +103,10 @@ struct InstanceRow: View {
             currentURL = selection
             connection = .pending
 
-            async let systemStatus = try dependencies.api.instance.systemStatus(instance)
+            async let systemStatus = try dependencies.api.instance.status(instance)
             async let rootFolders = try dependencies.api.instance.rootFolders(instance)
             async let qualityProfiles = try dependencies.api.instance.qualityProfiles(instance)
-            async let tags = dependencies.api.instance.getTags(instance)
+            async let tags = dependencies.api.instance.tags(instance)
 
             let data = try await systemStatus
 

--- a/Ruddarr/Views/Settings/InstanceRow.swift
+++ b/Ruddarr/Views/Settings/InstanceRow.swift
@@ -103,10 +103,10 @@ struct InstanceRow: View {
             currentURL = selection
             connection = .pending
 
-            async let systemStatus = try dependencies.api.systemStatus(instance)
-            async let rootFolders = try dependencies.api.rootFolders(instance)
-            async let qualityProfiles = try dependencies.api.qualityProfiles(instance)
-            async let tags = dependencies.api.getTags(instance)
+            async let systemStatus = try dependencies.api.instance.systemStatus(instance)
+            async let rootFolders = try dependencies.api.instance.rootFolders(instance)
+            async let qualityProfiles = try dependencies.api.instance.qualityProfiles(instance)
+            async let tags = dependencies.api.instance.getTags(instance)
 
             let data = try await systemStatus
 

--- a/Ruddarr/Views/Settings/InstanceView+Metadata.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Metadata.swift
@@ -72,8 +72,8 @@ extension InstanceView {
 
     private func fetchStats() async throws -> InstanceStats {
         switch instance.type {
-        case .radarr: await InstanceStats.make(movies: try await dependencies.api.fetchMovies(instance))
-        case .sonarr: await InstanceStats.make(series: try await dependencies.api.fetchSeries(instance))
+        case .radarr: await InstanceStats.make(movies: try await dependencies.api.radarr.fetchMovies(instance))
+        case .sonarr: await InstanceStats.make(series: try await dependencies.api.sonarr.fetchSeries(instance))
         }
     }
 
@@ -86,7 +86,7 @@ extension InstanceView {
         }
 
         do {
-            async let statusTask = dependencies.api.systemStatus(instance)
+            async let statusTask = dependencies.api.instance.systemStatus(instance)
 
             let stats = try await fetchStats()
 
@@ -139,7 +139,7 @@ extension InstanceView {
         diskSpaceState = .loading
 
         do {
-            diskSpaceState = .loaded(try await dependencies.api.fetchDiskSpace(instance))
+            diskSpaceState = .loaded(try await dependencies.api.instance.fetchDiskSpace(instance))
         } catch is CancellationError {
                 //
         } catch {

--- a/Ruddarr/Views/Settings/InstanceView+Metadata.swift
+++ b/Ruddarr/Views/Settings/InstanceView+Metadata.swift
@@ -72,8 +72,8 @@ extension InstanceView {
 
     private func fetchStats() async throws -> InstanceStats {
         switch instance.type {
-        case .radarr: await InstanceStats.make(movies: try await dependencies.api.radarr.fetchMovies(instance))
-        case .sonarr: await InstanceStats.make(series: try await dependencies.api.sonarr.fetchSeries(instance))
+        case .radarr: await InstanceStats.make(movies: try await dependencies.api.radarr.fetch(instance))
+        case .sonarr: await InstanceStats.make(series: try await dependencies.api.sonarr.fetch(instance))
         }
     }
 
@@ -86,7 +86,7 @@ extension InstanceView {
         }
 
         do {
-            async let statusTask = dependencies.api.instance.systemStatus(instance)
+            async let statusTask = dependencies.api.instance.status(instance)
 
             let stats = try await fetchStats()
 
@@ -139,7 +139,7 @@ extension InstanceView {
         diskSpaceState = .loading
 
         do {
-            diskSpaceState = .loaded(try await dependencies.api.instance.fetchDiskSpace(instance))
+            diskSpaceState = .loaded(try await dependencies.api.instance.diskSpace(instance))
         } catch is CancellationError {
                 //
         } catch {


### PR DESCRIPTION
Splits the flat `API` struct so endpoints are reached by dot, then drops the names the namespace now makes redundant:

```swift
dependencies.api.radarr.fetch(instance)
dependencies.api.sonarr.series(series.id, instance)
dependencies.api.instance.tags(instance)
```

Two commits: the split, then the renames.

## Why three namespaces, not two

Of the 41 endpoints, 15 are served identically by both apps, and their callers — `Queue`, `History`, `InstanceWebhook`, `TaskImportView`, `TaskRemovalView` and the settings views — iterate over `configuredInstances` without ever branching on `instance.type`. Forcing those into `.radarr`/`.sonarr` would mean either duplicating 15 identical closures across both `live` and `mock`, or adding an `if instance.type == .radarr` at every one of those call sites. Both are worse than the status quo, so they get their own namespace.

`command` and `downloadRelease` land in `instance` rather than being split per-type. They share a route across both apps and already discriminate on their payload — `InstanceCommand.payload` switches between `RadarrPayload`/`SonarrPayload`/`GenericPayload`, and `DownloadReleaseCommand` has three inits. Splitting them would mean splitting `InstanceCommand` into two enums for no gain.

## The renames

`get` is gone entirely. Radarr has exactly one entity, so all twelve endpoints drop `Movie`. Sonarr has three, so only `Series` is redundant — `Episode` stays wherever it distinguishes one collection from another, and on `episodeHistory` because Sonarr also serves `/history/series` even though only the episode route is called today.

| radarr | | sonarr | | instance | |
| --- | --- | --- | --- | --- | --- |
| `fetchMovies` | `fetch` | `fetchSeries` | `fetch` | `systemStatus` | `status` |
| `getMovie` | `movie` | `getSeries` | `series` | `fetchDiskSpace` | `diskSpace` |
| `lookupMovies` | `lookup` | `fetchEpisodes` | `episodes` | `getTags` | `tags` |
| `lookupMovieReleases` | `releases` | `lookupSeries` | `lookup` | `fetchQueueTasks` | `queue` |
| `getMovieHistory` | `history` | `lookupSeriesReleases` | `releases` | `fetchImportableFiles` | `importableFiles` |
| `getMovieFiles` | `files` | `addSeries` | `add` | `fetchHistory` | `history` |
| `getMovieExtraFiles` | `extraFiles` | `pushSeries` | `push` | `fetchNotifications` | `notifications` |
| `addMovie` | `add` | `updateSeries` | `update` | | |
| `updateMovie` | `update` | `deleteSeries` | `delete` | | |
| `deleteMovie` | `delete` | `getEpisodeHistory` | `episodeHistory` | | |
| `deleteMovieFile` | `deleteFile` | `episodeCalendar` | `calendar` | | |
| `movieCalendar` | `calendar` | | | | |

Unchanged: `monitorEpisode`, `deleteEpisodeFile`, `deleteEpisodeFiles`, `rootFolders`, `qualityProfiles`, `command`, `downloadRelease`, `deleteQueueTask`, `createNotification`, `updateNotification`, `deleteNotification`.

Dropping `get` also resolves the one naming collision the split would otherwise hit. "Series" is its own plural, so `fetchSeries` and `getSeries` both want the name `series`, and these are stored closure properties, which Swift cannot overload by signature. As `fetch` and `series` they no longer compete.

Reads are verbs in the media namespaces and nouns in `instance`, which is structural rather than arbitrary: `radarr` and `sonarr` have collection-versus-single pairs that need `fetch` to stay apart from `movie`/`series`, and `instance` has none — every read there is one fixed resource. That is what retires the arbitrary mix of `fetchDiskSpace`, `getTags` and `rootFolders` for identical GET semantics.

## Structure

- `API.swift` — `API` now holds `radarr: RadarrAPI`, `sonarr: SonarrAPI`, `instance: InstanceAPI`. The three structs are top-level so the third doesn't collide with the `Instance` model. `API.request` and `API.Error` are untouched, so the ~20 files holding an `API.Error` are unaffected.
- `API+Live.swift` — one `static var live` per struct. Closure bodies are verbatim; `request(…)` is now `API.request(…)` since the extensions are on different types.
- `API+Mock.swift` — same split. `loadPreviewData` moves from a `fileprivate extension API` static to a fileprivate function so the mock bodies stay verbatim alongside the existing `modifyQueueItems`/`modifyCalendar*` helpers. Same fixtures, same sleeps, same return values.
- 23 call-site files updated. No route, signature or behaviour changed, and no `project.pbxproj` change (no files added or moved).

The rename was scoped to declarations, init labels and `dependencies.api.<namespace>.<name>` call sites rather than applied by name — `addMovie`, `updateSeries` and `fetchHistory` also name unrelated view methods and `QuickActions` cases that must not move.

## Not built

There's no Swift toolchain in the environment this was written in, so it has not been compiled and the test suites have not been run — CI is the first real check. Verified by inspection instead: field declaration order matches the memberwise init order in both `live` and `mock` for all three structs (12/14/15), all 41 endpoints resolve at their call sites, and no line exceeds the 180-char SwiftLint limit. The three files are 371/344/303 lines, under the 400-line `file_length` warning.

## One thing worth a look

`dependencies.api.instance.tags(instance)` reads a little awkwardly where the local variable is also called `instance`. It compiles unambiguously — the existing `async let rootFolders = …rootFolders(instance)` already had this shape — but `.shared` or `.system` would avoid the echo if you'd prefer.

No `CHANGELOG.md` entry — this is an internal refactor with no user-facing effect.