### PR TITLE
Collapse episode descriptions when tapping again

### DIFF
--- a/Ruddarr/Views/Series/EpisodeView.swift
+++ b/Ruddarr/Views/Series/EpisodeView.swift
@@ -172,13 +172,13 @@ struct EpisodeView: View {
 
     var description: some View {
         HStack(alignment: .top) {
-            Text(episode.overview ?? "")
+            Text(descriptionTruncated ? (episode.overview ?? "").singleLined() : episode.overview ?? "")
                 .font(.callout)
                 .transition(.slide)
                 .lineLimit(descriptionTruncated ? 4 : nil)
                 .textSelection(.enabled)
                 .onTapGesture {
-                    withAnimation(.snappy) { descriptionTruncated = false }
+                    withAnimation(.snappy) { descriptionTruncated.toggle() }
                 }
 
             Spacer()


### PR DESCRIPTION
The Chaptarr backport made movie and series descriptions toggle on tap,
but episode descriptions still only expanded. Apply the same treatment so
tapping an expanded episode overview collapses it again, and so the
truncated text is single-lined to match.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018AvdUBFwAvFyd8devNoFkL